### PR TITLE
Fix Quarto publish workflow

### DIFF
--- a/.github/workflows/quarto.yml
+++ b/.github/workflows/quarto.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - uses: quarto-dev/quarto-actions/setup@v2
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter ipykernel pyyaml nbformat nbclient
       - name: Render
         run: quarto render


### PR DESCRIPTION
## Summary
- set up Python before running Quarto render
- install Jupyter dependencies needed by Quarto

## Testing
- `quarto render`

------
https://chatgpt.com/codex/tasks/task_e_6847d20bdf90832a8c378cbae0f9c585