### PR TITLE
Show posts on homepage

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -26,3 +26,4 @@ format:
   html:
     theme: distill
     toc: true
+    css: static/style.css

--- a/index.qmd
+++ b/index.qmd
@@ -1,9 +1,64 @@
 ---
-title: "Welcome"
+title: "Blog Posts"
+jupyter: python3
+execute:
+  echo: false
 ---
 
-# Welcome
+```{python}
+import glob, os
+from html import escape
+from IPython.display import HTML, display
 
-This is the home page for Aditya Mangal's blog.
 
-Visit the [posts section](posts/index.qmd) to browse past articles.
+def parse_front_matter(path):
+    yaml = {}
+    with open(path, encoding='utf-8') as fh:
+        lines = fh.readlines()
+    if not lines or lines[0].strip() != '---':
+        return yaml
+    for line in lines[1:]:
+        if line.strip() == '---':
+            break
+        if ':' not in line:
+            continue
+        key, val = line.split(':', 1)
+        yaml[key.strip()] = val.strip().strip('"').strip("'")
+    return yaml
+
+
+posts = []
+for f in glob.glob('posts/*.qmd'):
+    if os.path.basename(f) == 'index.qmd':
+        continue
+    meta = parse_front_matter(f)
+    slug = os.path.splitext(os.path.basename(f))[0]
+    url = f'posts/{slug}.html'
+    posts.append(
+        (
+            meta.get('date', ''),
+            meta.get('title', slug),
+            meta.get('summary', ''),
+            url,
+            meta.get('thumbnailImage') or meta.get('coverImage', ''),
+        )
+    )
+
+posts.sort(reverse=True)
+
+blocks = []
+for date, title, summary, url, image in posts:
+    img_tag = f'<img src="{escape(image)}" alt="{escape(title)}">' if image else ''
+    blocks.append(
+        f'''<div class="post-block">
+  <div class="post-info">
+    <h2><a href="{escape(url)}">{escape(title)}</a></h2>
+    <p>{escape(summary)}</p>
+  </div>
+  {img_tag}
+</div>'''
+    )
+
+display(HTML('\n'.join(blocks)))
+```
+

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,25 @@
+.post-block {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 1.5em;
+  padding-bottom: 1.5em;
+  border-bottom: 1px solid #eaeaea;
+}
+.post-block img {
+  width: 150px;
+  height: auto;
+  margin-left: 1em;
+  object-fit: cover;
+}
+.post-info {
+  flex: 1;
+}
+.post-info h2 {
+  margin-top: 0;
+  margin-bottom: 0.3em;
+}
+.post-info p {
+  margin: 0;
+  color: #555;
+}
+


### PR DESCRIPTION
## Summary
- list blog posts directly on the homepage
- add custom CSS for Distill-style post blocks

## Testing
- `quarto render`

------
https://chatgpt.com/codex/tasks/task_e_6847d6302884832aa3cb2f5a07a453ce