### PR TITLE
Add About page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -16,6 +16,8 @@ website:
         text: Home
       - href: posts/index.qmd
         text: Posts
+      - href: about.qmd
+        text: About
     right:
       - icon: github
         href: https://github.com/adityamangal410

--- a/about.qmd
+++ b/about.qmd
@@ -1,0 +1,26 @@
+---
+title: "About Me"
+image: static/profile.jpg
+format:
+  html:
+    toc: false
+---
+
+::: {.quarto-row}
+::: {.quarto-column about-img width="30%"}
+![Aditya Mangal](static/profile.jpg){#profile style="border-radius:50%; max-width:100%;"}
+:::
+::: {.quarto-column width="70%"}
+
+Hello! I'm **Aditya Mangal**. I'm currently working in the Search & Discovery Team at Roblox building the richest Recommendations Platform. Previously, I worked in the Location Center of Excellence at Yahoo. I'm originally from India and have been living in the San Francisco Bay Area for the past few years. I love blogging about Data Science and Machine Learning. Java was my first love and R/Python are competing for a close second. In an ideal world, I'd also share my musings about travel and photography here. If you have questions or feedback, feel free to reach out at [adityamangal410@yahoo.co.in](mailto:adityamangal410@yahoo.co.in).
+
+### Connect with me
+
+- [LinkedIn](https://www.linkedin.com/in/adityamangal410/)
+- [GitHub](https://github.com/adityamangal410)
+- [Twitter](https://twitter.com/adityamangal410)
+
+:::
+:::
+
+


### PR DESCRIPTION
## Summary
- create new `about.qmd` with bio details from old blogdown site
- add About page to navbar

## Testing
- `quarto render` *(fails: `quarto: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684847a8190c832a8d1e2cda7eee92eb