### PR TITLE
Implement distill-style post layout

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -7,6 +7,7 @@ execute:
 
 ```{python}
 import glob, os, re
+from typing import List
 from html import escape
 from IPython.display import HTML, display
 
@@ -17,13 +18,24 @@ def parse_front_matter(path):
         lines = fh.readlines()
     if not lines or lines[0].strip() != '---':
         return yaml
-    for line in lines[1:]:
+    i = 1
+    while i < len(lines):
+        line = lines[i]
+        i += 1
         if line.strip() == '---':
             break
-        if ':' not in line:
-            continue
-        key, val = line.split(':', 1)
-        yaml[key.strip()] = val.strip().strip('"').strip("'")
+        if ':' in line:
+            key, val = line.split(':', 1)
+            key = key.strip()
+            val = val.strip()
+            if val == '':
+                values: List[str] = []
+                while i < len(lines) and lines[i].startswith('  -'):
+                    values.append(lines[i].strip()[2:].strip())
+                    i += 1
+                yaml[key] = values
+            else:
+                yaml[key] = val.strip('"').strip("'")
     return yaml
 
 
@@ -61,6 +73,7 @@ for f in glob.glob('posts/*.qmd'):
     posts.append(
         (
             meta.get('date', ''),
+            meta.get('categories', []),
             meta.get('title', slug),
             meta.get('summary', ''),
             url,
@@ -71,10 +84,15 @@ for f in glob.glob('posts/*.qmd'):
 posts.sort(reverse=True)
 
 blocks = []
-for date, title, summary, url, image in posts:
+for date, cats, title, summary, url, image in posts:
     img_tag = f'<img src="{escape(image)}" alt="{escape(title)}">' if image else ''
+    cats_str = ', '.join(cats) if isinstance(cats, list) else cats
     blocks.append(
         f'''<div class="post-block">
+  <div class="post-meta">
+    <div class="post-date">{escape(date)}</div>
+    <div class="post-cats">{escape(cats_str)}</div>
+  </div>
   <div class="post-info">
     <h2><a href="{escape(url)}">{escape(title)}</a></h2>
     <p>{escape(summary)}</p>

--- a/static/style.css
+++ b/static/style.css
@@ -1,23 +1,39 @@
 .post-block {
-  display: flex;
-  align-items: flex-start;
-  margin-bottom: 1.5em;
-  padding-bottom: 1.5em;
+  display: grid;
+  grid-template-columns: 120px 1fr 200px;
+  grid-gap: 1em;
+  align-items: center;
+  padding: 1.5em 0;
   border-bottom: 1px solid #eaeaea;
 }
+
+.post-meta {
+  text-align: right;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.post-date {
+  margin-bottom: 0.25em;
+}
+
 .post-block img {
-  width: 150px;
+  width: 200px;
   height: auto;
-  margin-left: 1em;
   object-fit: cover;
 }
-.post-info {
-  flex: 1;
-}
+
 .post-info h2 {
-  margin-top: 0;
-  margin-bottom: 0.3em;
+  margin: 0 0 0.3em 0;
+  font-weight: 600;
+  color: #000;
 }
+
+.post-info h2 a {
+  text-decoration: none;
+  color: inherit;
+}
+
 .post-info p {
   margin: 0;
   color: #555;


### PR DESCRIPTION
## Summary
- parse categories from front matter in `index.qmd`
- render post metadata and restructure layout
- revise CSS for a Distill-style list layout

## Testing
- `quarto --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848993cb048832aa36092dc10291716