### PR TITLE
Fix about page column syntax

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -8,9 +8,9 @@ format:
 
 ::: {.columns}
 ::: {.column .about-img width="30%"}
-![Aditya Mangal](static/profile.jpg){#profile style="border-radius:50%; max-width:100%;"}
+<img src="static/profile.jpg" alt="Aditya Mangal" class="about-photo"/>
 :::
-::: {.column width="70%"}
+::: {.column .about-text width="70%"}
 
 Hello! I'm **Aditya Mangal**. I'm currently working in the Search & Discovery Team at Roblox building the richest Recommendations Platform. Previously, I worked in the Location Center of Excellence at Yahoo. I'm originally from India and have been living in the San Francisco Bay Area for the past few years. I love blogging about Data Science and Machine Learning. Java was my first love and R/Python are competing for a close second. In an ideal world, I'd also share my musings about travel and photography here. If you have questions or feedback, feel free to reach out at [adityamangal410@yahoo.co.in](mailto:adityamangal410@yahoo.co.in).
 

--- a/static/style.css
+++ b/static/style.css
@@ -59,3 +59,22 @@
   background-color: #ddd;
 }
 
+.about-img {
+  text-align: center;
+  padding-right: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.about-img img {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.about-text {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+


### PR DESCRIPTION
## Summary
- fix about page to use `.column` syntax

## Testing
- `quarto render about.qmd --output about_render.html`

------
https://chatgpt.com/codex/tasks/task_e_684915614dbc832a896b71e5ea85c6cd