### PR TITLE
Fix YouTube blocks

### DIFF
--- a/post/2019-04-22-the-mueller-report.html
+++ b/post/2019-04-22-the-mueller-report.html
@@ -305,7 +305,7 @@ def get_related_lines(query):
 <p>Lets see if we can catch (or fact check, if you will), any of the late night hosts’ jokes about the Mueller Report.</p>
 <div id="trevor-noah" class="section level3">
 <h3>Trevor Noah</h3>
-{{% youtube id="pVbwZg8rM2c" %}}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/pVbwZg8rM2c" frameborder="0" allowfullscreen></iframe>
 <pre class="r"><code>content %&gt;% 
   arrange(compound) %&gt;% 
   head(10) %&gt;% 
@@ -327,7 +327,7 @@ def get_related_lines(query):
 </div>
 <div id="stephen-colbert" class="section level3">
 <h3>Stephen Colbert</h3>
-{{% youtube id="7MursWMNONo" %}}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/7MursWMNONo" frameborder="0" allowfullscreen></iframe>
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;olc&quot;)) %&gt;% 
   select(text, page, line)</code></pre>
@@ -348,7 +348,7 @@ def get_related_lines(query):
 </div>
 <div id="jimmy-fallon" class="section level3">
 <h3>Jimmy Fallon</h3>
-{{% youtube id="TJZf0JIdqqU" %}}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/TJZf0JIdqqU" frameborder="0" allowfullscreen></iframe>
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;crazy&quot;)) %&gt;% 
   select(text, page, line)</code></pre>
@@ -372,7 +372,7 @@ House staff.”</p>
 </div>
 <div id="jimmy-kimmel" class="section level3">
 <h3>Jimmy Kimmel</h3>
-{{% youtube id="NB7ZMczCXEM" %}}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NB7ZMczCXEM" frameborder="0" allowfullscreen></iframe>
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;election interference&quot;)) %&gt;% 
   select(text, page, line)</code></pre>

--- a/post/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.html
+++ b/post/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.html
@@ -114,7 +114,7 @@ class DisasterTweetsClassifierRNN(pl.LightningModule):
 <p>Vanilla RNNs suffer from the problem of Vanishing Gradients. In simple words, the basic RNNs discussed above are more impacted by near word effects instead of words which are far away. So, for sentences with longer length, at each RNN step, the model is only able to carry information from the previous few words and not from the words which are farther away but may have more relevance to the word in current step.<br />
 The issue mainly arises because we completely modify hidden state and weights at each step based on the currently incoming word and the hidden state vector becomes an information bottleneck. GRUs try to fix this problem by controlling how much of the previous hidden vector is forgotten and how much of it is kept/updated. Another popular variant to fix this problem is the LSTM (Long Short Term Memory) network which tries to keep a separate vector (cell state) as “memory” to hold information over long sequences. However, I am using GRU in my work in favour of limited compute power.</p>
 <p>This lecture by Abigail See at Stanford is the best resource IMO to understand the issues with Vanilla RNNs and how GRUs and LSTMs work to try and resolve them.</p>
-{{% youtube id="QEw0qEa0E50" %}}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/QEw0qEa0E50" frameborder="0" allowfullscreen></iframe>
 <p>For our purposes, we create the GRU network as follows -</p>
 <pre class="python"><code>import pytorch_lightning as pl
 

--- a/posts/2019-04-22-the-mueller-report.qmd
+++ b/posts/2019-04-22-the-mueller-report.qmd
@@ -309,7 +309,7 @@ def get_related_lines(query):
 <p>Lets see if we can catch (or fact check, if you will), any of the late night hosts’ jokes about the Mueller Report.</p>
 <div id="trevor-noah" class="section level3">
 <h3>Trevor Noah</h3>
-{{% youtube id="pVbwZg8rM2c" %}}
+{{< video https://www.youtube.com/embed/pVbwZg8rM2c >}}
 <pre class="r"><code>content %&gt;% 
   arrange(compound) %&gt;% 
   head(10) %&gt;% 
@@ -331,7 +331,7 @@ def get_related_lines(query):
 </div>
 <div id="stephen-colbert" class="section level3">
 <h3>Stephen Colbert</h3>
-{{% youtube id="7MursWMNONo" %}}
+{{< video https://www.youtube.com/embed/7MursWMNONo >}}
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;olc&quot;)) %&gt;% 
   select(text, page, line)</code></pre>
@@ -352,7 +352,7 @@ def get_related_lines(query):
 </div>
 <div id="jimmy-fallon" class="section level3">
 <h3>Jimmy Fallon</h3>
-{{% youtube id="TJZf0JIdqqU" %}}
+{{< video https://www.youtube.com/embed/TJZf0JIdqqU >}}
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;crazy&quot;)) %&gt;% 
   select(text, page, line)</code></pre>
@@ -376,7 +376,7 @@ House staff.”</p>
 </div>
 <div id="jimmy-kimmel" class="section level3">
 <h3>Jimmy Kimmel</h3>
-{{% youtube id="NB7ZMczCXEM" %}}
+{{< video https://www.youtube.com/embed/NB7ZMczCXEM >}}
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;election interference&quot;)) %&gt;% 
   select(text, page, line)</code></pre>

--- a/posts/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.qmd
+++ b/posts/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.qmd
@@ -118,7 +118,7 @@ class DisasterTweetsClassifierRNN(pl.LightningModule):
 <p>Vanilla RNNs suffer from the problem of Vanishing Gradients. In simple words, the basic RNNs discussed above are more impacted by near word effects instead of words which are far away. So, for sentences with longer length, at each RNN step, the model is only able to carry information from the previous few words and not from the words which are farther away but may have more relevance to the word in current step.<br />
 The issue mainly arises because we completely modify hidden state and weights at each step based on the currently incoming word and the hidden state vector becomes an information bottleneck. GRUs try to fix this problem by controlling how much of the previous hidden vector is forgotten and how much of it is kept/updated. Another popular variant to fix this problem is the LSTM (Long Short Term Memory) network which tries to keep a separate vector (cell state) as “memory” to hold information over long sequences. However, I am using GRU in my work in favour of limited compute power.</p>
 <p>This lecture by Abigail See at Stanford is the best resource IMO to understand the issues with Vanilla RNNs and how GRUs and LSTMs work to try and resolve them.</p>
-{{% youtube id="QEw0qEa0E50" %}}
+{{< video https://www.youtube.com/embed/QEw0qEa0E50 >}}
 <p>For our purposes, we create the GRU network as follows -</p>
 <pre class="python"><code>import pytorch_lightning as pl
 


### PR DESCRIPTION
## Summary
- migrate old `{{% youtube %}}` shortcodes to the Quarto video shortcode
- replace legacy YouTube blocks in archived HTML posts

## Testing
- `quarto render`

------
https://chatgpt.com/codex/tasks/task_e_68491610089c832abb8fd18e56da1e60