### PR TITLE
Add category link buttons on posts

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -32,4 +32,6 @@ format:
     theme: distill
     toc: true
     css: static/style.css
-    include-after-body: static/disqus.html
+    include-after-body:
+      - static/categories.html
+      - static/disqus.html

--- a/static/categories.html
+++ b/static/categories.html
@@ -1,0 +1,10 @@
+<script>
+var offset = '';
+var meta = document.querySelector('meta[name="quarto:offset"]');
+if (meta) {
+  offset = meta.getAttribute('content') || '';
+}
+var script = document.createElement('script');
+script.src = offset + 'static/categories.js';
+document.currentScript.parentNode.insertBefore(script, document.currentScript);
+</script>

--- a/static/categories.js
+++ b/static/categories.js
@@ -1,0 +1,13 @@
+// Convert category labels to links
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.quarto-category').forEach(el => {
+    const text = el.textContent.trim();
+    if (!text) return;
+    const slug = text.toLowerCase().replace(/\s+/g, '-');
+    const link = document.createElement('a');
+    link.textContent = text;
+    link.href = `../categories/${slug}.html`;
+    link.className = 'quarto-category cat-link';
+    el.replaceWith(link);
+  });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -44,7 +44,7 @@
   margin-bottom: 0.25em;
 }
 
-.post-cats a.cat-link {
+.cat-link {
   display: inline-block;
   padding: 0.2em 0.5em;
   margin-left: 0.2em;
@@ -55,7 +55,7 @@
   color: #333;
 }
 
-.post-cats a.cat-link:hover {
+.cat-link:hover {
   background-color: #ddd;
 }
 


### PR DESCRIPTION
## Summary
- make generic `.cat-link` style for categories
- load new JS to transform post categories into links
- include categories HTML snippet in Quarto config

## Testing
- `quarto render posts/2019-05-07-india-general-elections-2019-analysis.qmd`
- `quarto render`

------
https://chatgpt.com/codex/tasks/task_e_684926cfeda4832ab99f4dfe18a2e862