### PR TITLE
Fix Netlify build by installing Quarto manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@ blogdown
 content/data
 _site/
 
+/node_modules
+package-lock.json
+
 /.quarto/

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,7 @@
 
 [build]
 publish = "_site"
-command = "pip install -r requirements.txt && quarto render"
+command = "pip install -r requirements.txt && bash tools/install_quarto.sh && /tmp/quarto/bin/quarto render"
 
 [build.environment]
 PYTHON_VERSION = "3.11"
-
-[[plugins]]
-package = "@quarto/netlify-plugin-quarto"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,1 @@
-{
-  "dependencies": {
-    "@quarto/netlify-plugin-quarto": "^0.0.5"
-  }
-}
+{}

--- a/tools/install_quarto.sh
+++ b/tools/install_quarto.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=${QUARTO_VERSION:-1.7.31}
+url="https://github.com/quarto-dev/quarto-cli/releases/download/v${version}/quarto-${version}-linux-amd64.tar.gz"
+
+mkdir -p /tmp/quarto
+curl -L "$url" -o /tmp/quarto/quarto.tar.gz
+
+# Extract and strip first component
+cd /tmp/quarto
+tar -xzf quarto.tar.gz --strip-components=1


### PR DESCRIPTION
## Summary
- install Quarto during Netlify build instead of using plugin
- ignore node_modules and lock file

## Testing
- `bash tools/install_quarto.sh`
- `/tmp/quarto/bin/quarto render`

------
https://chatgpt.com/codex/tasks/task_e_6849c01d9f74832a856d73d4ff22df33