### PR TITLE
Switch Rmd conversions to markdown headings

### DIFF
--- a/posts/2017-09-28-india-transportation-accidents-exploration-project.qmd
+++ b/posts/2017-09-28-india-transportation-accidents-exploration-project.qmd
@@ -26,23 +26,13 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#project-summary">Project Summary</a></li>
-<li><a href="#project-goals">Project Goals</a></li>
-</ul>
-</div>
 
-<div id="project-summary" class="section level1">
-<h1>Project Summary</h1>
+# Project Summary
 <p>With this project I will try to visualize and understand the traffic accident data for India as publicly accessible <a href="https://data.gov.in/">here</a>.</p>
-</div>
-<div id="project-goals" class="section level1">
-<h1>Project Goals</h1>
+# Project Goals
 <ol style="list-style-type: decimal">
 <li><p>Visualize traffic information and find trends</p></li>
 <li><p>Find outliers and see if any valuable info can be dugout for each state or overall.</p></li>
 <li><p>Try to predict number of accidents or other useful information.</p></li>
 </ol>
 <p>I’ll put out notebooks related to the work as separate articles.</p>
-</div>

--- a/posts/2018-02-15-the-winter-olympics-makeovermonday-2018-week7.qmd
+++ b/posts/2018-02-15-the-winter-olympics-makeovermonday-2018-week7.qmd
@@ -38,27 +38,12 @@ freeze: true
 <link href="/rmarkdown-libs/rstudio_leaflet/rstudio_leaflet.css" rel="stylesheet" />
 <script src="/rmarkdown-libs/leaflet-binding/leaflet.js"></script>
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#cleaning-up-workspace-and-loading-required-libraries">Cleaning up workspace and loading required libraries</a></li>
-<li><a href="#obtaining-data">Obtaining Data</a></li>
-<li><a href="#scrubbing-data">Scrubbing data</a></li>
-<li><a href="#exploring-data">Exploring Data</a></li>
-</ul></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Goal of this Visualization task is to create an alternative visualization to the <a href="https://public.tableau.com/views/TheWinterOlympics/TheWinterOlympics?:embed=y&:showVizHome=no" target="_blank">Tableau’s visualization for Winter Olympics data for different countries</a></p>
 <p>In this blog post, I’m trying to generate a World Choropleth Map showing the total counts of medals for each country.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="cleaning-up-workspace-and-loading-required-libraries" class="section level2">
-<h2>Cleaning up workspace and loading required libraries</h2>
+# Analysis
+## Cleaning up workspace and loading required libraries
 <pre class="r"><code>rm(list = ls())</code></pre>
 <pre class="r"><code>library(tidyverse) #Data Wrangling
 library(httr)
@@ -68,9 +53,7 @@ library(leaflet)
 library(rgeos)
 library(rgdal)
 library(stringr)</code></pre>
-</div>
-<div id="obtaining-data" class="section level2">
-<h2>Obtaining Data</h2>
+## Obtaining Data
 <p>Reading and viewing the dataset</p>
 <pre class="r"><code>GET(&quot;https://query.data.world/s/n5nc32oqhtb25hdt3vsa24rd4scs2w&quot;, write_disk(tf &lt;- tempfile(fileext = &quot;.xlsx&quot;)))</code></pre>
 <pre class="r"><code>olympics = read_excel(tf)</code></pre>
@@ -129,9 +112,7 @@ library(stringr)</code></pre>
 ##  3rd Qu.:28.00  
 ##  Max.   :42.00  
 ##  NA&#39;s   :692</code></pre>
-</div>
-<div id="scrubbing-data" class="section level2">
-<h2>Scrubbing data</h2>
+## Scrubbing data
 <p>As per the dataset requirement, East and West Germany are to be grouped with Germany and Soviet Union and the 1992 Unified Team needs to be combined with Russia</p>
 <pre class="r"><code>olympics = olympics %&gt;% 
   mutate(Country = recode(Country, &quot;Soviet Union&quot; = &quot;Russia&quot;, &quot;Unified Team&quot; = &quot;Russia&quot;,
@@ -294,9 +275,7 @@ TotalMedalsPerCountry</code></pre>
 ## 10 Italy                    ITA           114
 ## # … with 29 more rows</code></pre>
 <p>Germany obtained the most number of medals (377) closely followed by Russia with (341)</p>
-</div>
-<div id="exploring-data" class="section level2">
-<h2>Exploring Data</h2>
+## Exploring Data
 <p>Lets plot the above data on a map using leaflet.</p>
 <p>Loading shape file data set from <a href="http://thematicmapping.org/downloads/world_borders.php">World Borders Dataset</a>.</p>
 <pre class="r"><code>shape = readOGR(&quot;~/Downloads/TM_WORLD_BORDERS_SIMPL-0.3/TM_WORLD_BORDERS_SIMPL-0.3.shp&quot;)</code></pre>
@@ -326,5 +305,3 @@ TotalMedalsPerCountry %&gt;%
 <script type="application/json" data-for="htmlwidget-1">{"x":{"options":{"crs":{"crsClass":"L.CRS.EPSG3857","code":null,"proj4def":null,"projectedBounds":null,"options":{}}},"calls":[{"method":"addTiles","args":["//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",null,null,{"minZoom":0,"maxZoom":18,"tileSize":256,"subdomains":"abc","errorTileUrl":"","tms":false,"noWrap":false,"zoomOffset":0,"zoomReverse":false,"opacity":1,"zIndex":1,"detectRetina":false,"attribution":"&copy; <a href=\"http://openstreetmap.org\">OpenStreetMap<\/a> contributors, <a href=\"http://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA<\/a>"}]},{"method":"addCircles","args":[[-24.973,47.683,53.54,50.643,42.761,59.081,33.42,45.723,56.058,58.674,64.504,46.565,51.11,47.07,42.7,36.491,48.16,39.778,56.858,47.153,49.771,52.077,-42.634,61.152,52.125,45.844,61.988,48.707,46.124,40.227,62.011,46.861,49.016,53,39.622,41.75],[136.189,14.912,28.047,4.664,25.231,-109.433,106.514,16.693,9.264,25.793,26.272,2.55,9.851,19.134,12.8,139.068,67.301,126.451,25.641,9.555,6.088,5.389,172.235,8.74,19.401,24.969,96.689,19.491,14.827,-3.649,15.27,7.908,31.388,-1.6,-98.606,63.17],10,null,null,{"interactive":true,"className":"","stroke":true,"color":["#F46D43","#66BD63","#F46D43","#D73027","#D73027","#A6D96A","#FFFFBF","#F46D43","#D73027","#D73027","#A6D96A","#D9EF8B","#1A9850","#D73027","#D9EF8B","#FEE08B","#D73027","#D73027","#D73027","#D73027","#D73027","#D9EF8B","#D73027","#1A9850","#FDAE61","#D73027","#1A9850","#D73027","#F46D43","#D73027","#D9EF8B","#D9EF8B","#D73027","#FDAE61","#66BD63","#D73027"],"weight":10,"opacity":0.5,"fill":true,"fillColor":["#F46D43","#66BD63","#F46D43","#D73027","#D73027","#A6D96A","#FFFFBF","#F46D43","#D73027","#D73027","#A6D96A","#D9EF8B","#1A9850","#D73027","#D9EF8B","#FEE08B","#D73027","#D73027","#D73027","#D73027","#D73027","#D9EF8B","#D73027","#1A9850","#FDAE61","#D73027","#1A9850","#D73027","#F46D43","#D73027","#D9EF8B","#D9EF8B","#D73027","#FDAE61","#66BD63","#D73027"],"fillOpacity":0.2},null,null,["Australia - TotalMedals - 12","Austria - TotalMedals - 218","Belarus - TotalMedals - 15","Belgium - TotalMedals - 5","Bulgaria - TotalMedals - 6","Canada - TotalMedals - 170","China - TotalMedals - 53","Croatia - TotalMedals - 11","Denmark - TotalMedals - 1","Estonia - TotalMedals - 7","Finland - TotalMedals - 161","France - TotalMedals - 109","Germany - TotalMedals - 377","Hungary - TotalMedals - 6","Italy - TotalMedals - 114","Japan - TotalMedals - 45","Kazakhstan - TotalMedals - 7","Korea, Democratic People's Republic of - TotalMedals - 2","Latvia - TotalMedals - 7","Liechtenstein - TotalMedals - 9","Luxembourg - TotalMedals - 2","Netherlands - TotalMedals - 110","New Zealand - TotalMedals - 1","Norway - TotalMedals - 329","Poland - TotalMedals - 20","Romania - TotalMedals - 1","Russia - TotalMedals - 341","Slovakia - TotalMedals - 5","Slovenia - TotalMedals - 15","Spain - TotalMedals - 2","Sweden - TotalMedals - 144","Switzerland - TotalMedals - 138","Ukraine - TotalMedals - 7","United Kingdom - TotalMedals - 26","United States - TotalMedals - 282","Uzbekistan - TotalMedals - 1"],{"interactive":false,"permanent":false,"direction":"auto","opacity":1,"offset":[0,0],"textsize":"10px","textOnly":false,"className":"","sticky":true},null,null]}],"setView":[[1.369002,53.019815],1,[]],"limits":{"lat":[-42.634,64.504],"lng":[-109.433,172.235]}},"evals":[],"jsHooks":[]}</script>
 <p>As can be clearly seen above, Norway and USA closely followed in the total medals ranking.
 Visualizing data on a map can provide a clear view of the overall data.</p>
-</div>
-</div>

--- a/posts/2018-02-18-where-does-your-medicine-come-from-makeovermonday-2018-week-8.qmd
+++ b/posts/2018-02-18-where-does-your-medicine-come-from-makeovermonday-2018-week-8.qmd
@@ -29,35 +29,18 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#cleaning-up-workspace-and-loading-required-libraries">Cleaning up workspace and loading required libraries</a></li>
-<li><a href="#obtaining-data">Obtaining Data</a></li>
-<li><a href="#scrubbing-data">Scrubbing data</a></li>
-<li><a href="#exploring-data">Exploring Data</a></li>
-</ul></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Goal of this Visualization task is to create a visualization for the <a href="https://www.trademap.org/Country_SelProduct_TS.aspx?nvpm=1|||||3004|||4|1|1|2|2|1|2|1|1" target="_blank">Drug and Medicine Exports data for different countries.</a></p>
 <p>In this blog post, I’m trying to find the leading countries in Export across these 5 years.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="cleaning-up-workspace-and-loading-required-libraries" class="section level2">
-<h2>Cleaning up workspace and loading required libraries</h2>
+# Analysis
+## Cleaning up workspace and loading required libraries
 <pre class="r"><code>rm(list = ls())</code></pre>
 <pre class="r"><code>library(tidyverse) #Data Wrangling
 library(&quot;httr&quot;)
 library(readxl) #Data Ingestion
 library(ggplot2) #Data Visualization</code></pre>
-</div>
-<div id="obtaining-data" class="section level2">
-<h2>Obtaining Data</h2>
+## Obtaining Data
 <p>Reading and viewing the dataset</p>
 <pre class="r"><code>GET(&quot;https://query.data.world/s/utmlfljjzc2naoeielefxsf4fh5qkf&quot;, write_disk(tf &lt;- tempfile(fileext = &quot;.xlsx&quot;)))</code></pre>
 <pre class="r"><code>drugs &lt;- read_excel(tf)</code></pre>
@@ -94,9 +77,7 @@ library(ggplot2) #Data Visualization</code></pre>
 ##                     3rd Qu.:2016   3rd Qu.:3.293e+08  
 ##                     Max.   :2017   Max.   :3.405e+11  
 ##                                    NA&#39;s   :266</code></pre>
-</div>
-<div id="scrubbing-data" class="section level2">
-<h2>Scrubbing data</h2>
+## Scrubbing data
 <p>Removing rows with NA for the purposes of this visualization</p>
 <pre class="r"><code>drugs = drugs %&gt;% 
   filter(!is.na(`Exports (USD)`))</code></pre>
@@ -119,9 +100,7 @@ library(ggplot2) #Data Visualization</code></pre>
 ##  9 Italy                      76012918000
 ## 10 Netherlands                59659401000
 ## # … with 210 more rows</code></pre>
-</div>
-<div id="exploring-data" class="section level2">
-<h2>Exploring Data</h2>
+## Exploring Data
 <p>Lets plot the countries which were among the top 5 exporters each year and each of their performance over these 5 years.</p>
 <pre class="r"><code>top5ExportersByYear = drugs %&gt;% 
   filter(Exporter!=&quot;World&quot;) %&gt;% 
@@ -200,5 +179,3 @@ yearlyTop10s</code></pre>
 <pre class="r"><code>plotTop10(yearlyTop10s %&gt;% filter(Year==2016))</code></pre>
 <p><img src="/post/2018-02-18-where-does-your-medicine-come-from-makeovermonday-2018-week-8_files/figure-html/unnamed-chunk-7-4.png" width="672" /></p>
 <p>As can be seen Germany remains the biggest exporter of Drugs and Medicines over the past 5 years.</p>
-</div>
-</div>

--- a/posts/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019.qmd
+++ b/posts/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019.qmd
@@ -22,23 +22,11 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#when-in-the-day-do-we-see-bikers">When in the day do we see bikers?</a></li>
-<li><a href="#what-directions-do-people-commute-by-bike">What directions do people commute by bike?</a></li>
-</ul></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level2">
-<h2>Introduction</h2>
+## Introduction
 <p>From the article on <a href="https://www.seattletimes.com/seattle-news/transportation/what-we-can-learn-from-seattles-bike-counter-data/">Seattle Times</a> -</p>
 <p>“While millions of public dollars are going for bike lanes in Seattle, the city’s data collection on actual bike-lane ridership is scattered and incomplete. Given they’re the best the public can get, here’s what those numbers can tell us about who’s riding where.”</p>
-</div>
-<div id="analysis" class="section level2">
-<h2>Analysis</h2>
+## Analysis
 <p>Following along the <a href="https://www.youtube.com/watch?v=sBho2GJE5lc">screencast</a> from <a href="https://twitter.com/drob">David Robinson</a></p>
 <pre class="r"><code>library(tidyverse)
 library(lubridate)
@@ -94,8 +82,7 @@ bike_traffic</code></pre>
   geom_histogram() +
   facet_grid(crossing ~ direction)</code></pre>
 <p><img src="/post/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019_files/figure-html/unnamed-chunk-5-1.png" width="672" /></p>
-<div id="when-in-the-day-do-we-see-bikers" class="section level3">
-<h3>When in the day do we see bikers?</h3>
+### When in the day do we see bikers?
 <pre class="r"><code>bike_traffic %&gt;% 
   group_by(hour = hour(date)) %&gt;% 
   summarise(bike_count = sum(bike_count, na.rm = TRUE)) %&gt;% 
@@ -201,9 +188,7 @@ bike_by_time_window %&gt;%
        y = &quot;% of yearly trips in this month&quot;,
        x = &quot;&quot;)</code></pre>
 <p><img src="/post/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019_files/figure-html/unnamed-chunk-13-1.png" width="672" /></p>
-</div>
-<div id="what-directions-do-people-commute-by-bike" class="section level3">
-<h3>What directions do people commute by bike?</h3>
+### What directions do people commute by bike?
 <pre class="r"><code>bike_traffic %&gt;% 
   filter(crossing != &quot;MTS Trail&quot;) %&gt;% 
   filter(!wday(date, label = TRUE) %in% c(&quot;Sat&quot;, &quot;Sun&quot;)) %&gt;% 
@@ -253,5 +238,3 @@ bike_by_direction_hour_crossing %&gt;%
        subtitle = &quot;Based on weekday crossings at six Seattle locations from 2014-Feb 2019&quot;,
        color = &quot;Direction&quot;)</code></pre>
 <p><img src="/post/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019_files/figure-html/unnamed-chunk-15-1.png" width="672" /></p>
-</div>
-</div>

--- a/posts/2019-04-16-economist-s-visualization-mistakes.qmd
+++ b/posts/2019-04-16-economist-s-visualization-mistakes.qmd
@@ -26,33 +26,14 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#analyzing-britains-political-left">Analyzing Britain’s Political Left</a></li>
-<li><a href="#analyzing-decline-of-dog-weights">Analyzing decline of dog weights</a></li>
-<li><a href="#analyzing-brexit-data">Analyzing Brexit data</a></li>
-<li><a href="#analyzing-us-trade-deficit">Analyzing US trade deficit</a></li>
-<li><a href="#analyzing-pension-benefits">Analyzing pension benefits</a></li>
-<li><a href="#analyzing-eu-balance">Analyzing EU balance</a></li>
-<li><a href="#analyzing-papers-published">Analyzing papers published</a></li>
-</ul></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>From the article on <a href="https://medium.economist.com/mistakes-weve-drawn-a-few-8cdd8a42d368">Mistakes, we’ve drawn a few</a> -</p>
 <p>“At The Economist, we take data visualisation seriously. Every week we publish around 40 charts across print, the website and our apps. With every single one, we try our best to visualise the numbers accurately and in a way that best supports the story. But sometimes we get it wrong. We can do better in future if we learn from our mistakes — and other people may be able to learn from them, too.”</p>
 <p>Here I will try and draw the improved plots as suggested by the article on economist or make a version I think is best.
 All this done towards the weekly social data project <a href="https://github.com/rfordatascience/tidytuesday/tree/master/data/2019/2019-04-16">Tidy Tuesday</a>.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(lubridate)
@@ -60,9 +41,7 @@ library(ggplot2)
 library(gridExtra)
 library(scales)
 theme_set(theme_light())</code></pre>
-</div>
-<div id="analyzing-britains-political-left" class="section level2">
-<h2>Analyzing Britain’s Political Left</h2>
+## Analyzing Britain’s Political Left
 <pre class="r"><code>corbyn &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/corbyn.csv&quot;)
 
 corbyn</code></pre>
@@ -86,9 +65,7 @@ corbyn</code></pre>
        title = &quot;Percentage of Average Facebook likes for different political groups&quot;,
        caption = &quot;Based on data from The Economist about political left in Britain&quot;)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-3-1.png" width="672" /></p>
-</div>
-<div id="analyzing-decline-of-dog-weights" class="section level2">
-<h2>Analyzing decline of dog weights</h2>
+## Analyzing decline of dog weights
 <pre class="r"><code>dogs &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/dogs.csv&quot;)
 
 dogs</code></pre>
@@ -116,9 +93,7 @@ dogs</code></pre>
        title = &quot;Average Weight to Neck Ratio over Years&quot;,
        caption = &quot;Based on data from The Economist&quot;)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-5-1.png" width="672" /></p>
-</div>
-<div id="analyzing-brexit-data" class="section level2">
-<h2>Analyzing Brexit data</h2>
+## Analyzing Brexit data
 <pre class="r"><code>brexit &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/brexit.csv&quot;)
 
 brexit</code></pre>
@@ -151,9 +126,7 @@ brexit</code></pre>
        caption = &quot;Based on data from The Economist&quot;,
        color = &quot;Response&quot;)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-7-1.png" width="672" /></p>
-</div>
-<div id="analyzing-us-trade-deficit" class="section level2">
-<h2>Analyzing US trade deficit</h2>
+## Analyzing US trade deficit
 <pre class="r"><code>trade &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/trade.csv&quot;)
 
 trade</code></pre>
@@ -197,9 +170,7 @@ trade %&gt;%
 
 grid.arrange(p1, p2, nrow = 1)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-9-1.png" width="672" /></p>
-</div>
-<div id="analyzing-pension-benefits" class="section level2">
-<h2>Analyzing pension benefits</h2>
+## Analyzing pension benefits
 <pre class="r"><code>pensions &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/pensions.csv&quot;)
 
 pensions</code></pre>
@@ -228,9 +199,7 @@ pensions</code></pre>
        subtitle = &quot;Size of point represents the spend per head&quot;,
        caption = &quot;Based on data from The Economist&quot;)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-11-1.png" width="672" /></p>
-</div>
-<div id="analyzing-eu-balance" class="section level2">
-<h2>Analyzing EU balance</h2>
+## Analyzing EU balance
 <pre class="r"><code>eu_balance &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/eu_balance.csv&quot;)
 
 eu_balance</code></pre>
@@ -265,9 +234,7 @@ eu_balance</code></pre>
        subtitle = &quot;Based on percentage of balances&quot;,
        caption = &quot;Based on data from The Economist&quot;)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-13-1.png" width="672" /></p>
-</div>
-<div id="analyzing-papers-published" class="section level2">
-<h2>Analyzing papers published</h2>
+## Analyzing papers published
 <pre class="r"><code>women_research &lt;- readr::read_csv(&quot;https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/women_research.csv&quot;)
 
 women_research</code></pre>
@@ -297,5 +264,3 @@ women_research</code></pre>
        color = &quot;Country&quot;,
        caption = &quot;Based on data from The Economist&quot;)</code></pre>
 <p><img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-15-1.png" width="960" /></p>
-</div>
-</div>

--- a/posts/2019-04-22-the-mueller-report.qmd
+++ b/posts/2019-04-22-the-mueller-report.qmd
@@ -31,45 +31,11 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#downloading-report">Downloading Report</a></li>
-<li><a href="#cleaning">Cleaning</a><ul>
-<li><a href="#page-range">Page range</a></li>
-<li><a href="#text-na">Text NA</a></li>
-<li><a href="#misspelled-words">Misspelled Words</a></li>
-<li><a href="#normalize">Normalize</a></li>
-</ul></li>
-<li><a href="#most-popular-words">Most popular words</a></li>
-<li><a href="#most-dramatic-pages">Most dramatic pages</a></li>
-<li><a href="#most-common-correlated-words">Most Common Correlated Words</a></li>
-<li><a href="#search-engine">Search Engine</a><ul>
-<li><a href="#search-query---michael-cohen">Search Query - Michael Cohen</a></li>
-<li><a href="#search-query---vladimir-putin">Search Query - Vladimir Putin</a></li>
-</ul></li>
-<li><a href="#late-night-hosts-jokes">Late Night Hosts’ Jokes</a><ul>
-<li><a href="#trevor-noah">Trevor Noah</a></li>
-<li><a href="#stephen-colbert">Stephen Colbert</a></li>
-<li><a href="#jimmy-fallon">Jimmy Fallon</a></li>
-<li><a href="#jimmy-kimmel">Jimmy Kimmel</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Analyzing the Special Counsel’s “Report On The Investigation Into Russian Interference In The 2016 Presidential Election” from - <a href="https://www.justice.gov/storage/report.pdf">justice.gov</a>.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -86,9 +52,7 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="downloading-report" class="section level2">
-<h2>Downloading Report</h2>
+## Downloading Report
 <p>If we want to download and parse the report ourselves we can do so as follows -</p>
 <pre class="r"><code>download.file(&quot;https://www.justice.gov/storage/report.pdf&quot;, &quot;~/Downloads/mueller-report.pdf&quot;)
 
@@ -102,23 +66,16 @@ report %&gt;%
 ## $ page &lt;dbl&gt; 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3…
 ## $ line &lt;dbl&gt; 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 1, 2, 3, 4, 5, 6…
 ## $ text &lt;chr&gt; &quot;U.S. Department of Justice&quot;, &quot;AttarAe:,c\\\\&#39;erlc Predtiet // M…</code></pre>
-</div>
-<div id="cleaning" class="section level2">
-<h2>Cleaning</h2>
-<div id="page-range" class="section level3">
-<h3>Page range</h3>
+## Cleaning
+### Page range
 <p>As we see from the pdf, first few pages contain Title and Index of the report, and the actual report text starts from page 9. Filtering out all the other pages for exploration</p>
 <pre class="r"><code>report %&gt;% 
   filter(page &gt;= 9) -&gt; content</code></pre>
-</div>
-<div id="text-na" class="section level3">
-<h3>Text NA</h3>
+### Text NA
 <p>There are about 386 rows with NA as text, these maybe because of parsing failures over redactions, among other things. Dropping them for now.</p>
 <pre class="r"><code>content %&gt;% 
   filter(!is.na(text)) -&gt; content</code></pre>
-</div>
-<div id="misspelled-words" class="section level3">
-<h3>Misspelled Words</h3>
+### Misspelled Words
 <pre class="r"><code>content %&gt;% 
   rowwise() %&gt;% 
   mutate(num_misspelled_words = length(hunspell(text)[[1]]),
@@ -128,15 +85,10 @@ report %&gt;%
 <p>Dropping all rows (around 400 rows) where percentage of misspelled words is more than 50%. Assuming these are introduced because of pdf parsing errors over redactions.</p>
 <pre class="r"><code>content %&gt;% 
   filter(perc_misspelled &lt;= 0.5) -&gt; content</code></pre>
-</div>
-<div id="normalize" class="section level3">
-<h3>Normalize</h3>
+### Normalize
 <pre class="r"><code>content %&gt;% 
   unnest_tokens(text, text, token = &quot;lines&quot;) -&gt; content</code></pre>
-</div>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most popular words</h2>
+## Most popular words
 <pre class="r"><code>tidy_content &lt;- content %&gt;%
   unnest_tokens(word, text) %&gt;%
   anti_join(stop_words)</code></pre>
@@ -160,9 +112,7 @@ report %&gt;%
        subtitle = &quot;Words occurring more than 400 times&quot;,
        caption = &quot;Based on data from the Mueller Report&quot;)</code></pre>
 <p><img src="/post/2019-04-22-the-mueller-report_files/figure-html/unnamed-chunk-10-1.png" width="672" /></p>
-</div>
-<div id="most-dramatic-pages" class="section level2">
-<h2>Most dramatic pages</h2>
+## Most dramatic pages
 <p>Using python’s NLTK’s Vader Lexicon to generate sentiments for each line.</p>
 <pre class="python"><code>import pandas as pd
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
@@ -220,9 +170,7 @@ content %&gt;%
 ##  8 &quot;one), three defendants with conspiracy to commit wire fraud and •bank…   182
 ##  9 &quot;guilty, pursuant to a single-count information , to identity fraud , …   183
 ## 10 &quot;difficult to argue that hacked emails in electronic form, which are t…   184</code></pre>
-</div>
-<div id="most-common-correlated-words" class="section level2">
-<h2>Most Common Correlated Words</h2>
+## Most Common Correlated Words
 <pre class="r"><code>word_cors &lt;- tidy_content %&gt;% 
   add_count(word) %&gt;% 
   filter(n &gt; stats::quantile(n, 0.7)) %&gt;% 
@@ -246,9 +194,7 @@ word_cors %&gt;%
        caption = &quot;Based on data from the Mueller Report&quot;)</code></pre>
 <p><img src="/post/2019-04-22-the-mueller-report_files/figure-html/unnamed-chunk-16-1.png" width="672" /></p>
 <p>Words like “mcgahn” and “comey” show up as centers of correlation network.</p>
-</div>
-<div id="search-engine" class="section level2">
-<h2>Search Engine</h2>
+## Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make this document more easily searchable and gain context using most related lines in the report for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -263,8 +209,7 @@ def get_related_lines(query):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="search-query---michael-cohen" class="section level3">
-<h3>Search Query - Michael Cohen</h3>
+### Search Query - Michael Cohen
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;michael cohen&quot;)) %&gt;% 
   select(text, page, line)</code></pre>
@@ -282,9 +227,7 @@ def get_related_lines(query):
 ## 9 &quot;organization before the house oversight and ref orm committee, 1…   348    50</code></pre>
 <p>One of the interesting results from above (page 357) -<br />
 “Toll records show that Cohen was connected to a White House phone number for approximately five minutes on January 19, 2018, and for approximately seven minutes on January 30, 2018, and that Cohen called Melania Trump’s cell phone several times between January 26, 2018, and January 30, 2018. Call Records of Michael Cohen.”</p>
-</div>
-<div id="search-query---vladimir-putin" class="section level3">
-<h3>Search Query - Vladimir Putin</h3>
+### Search Query - Vladimir Putin
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;vladimir putin&quot;)) %&gt;% 
   select(text, page, line)</code></pre>
@@ -302,13 +245,9 @@ def get_related_lines(query):
 ## 9 &quot;kuznetsov, sergey        russian government official at the russ…   406    18</code></pre>
 <p>One of the interesting results from above (page 92) -<br />
 “On March 24, 2016, Papadopoulos met with Mifsud in London. Mifsud was accompanied by a russian female named olga polonskaya. Mifsud introduced Polonskaya as a former student of his who had connections to Vladimir Putin”</p>
-</div>
-</div>
-<div id="late-night-hosts-jokes" class="section level2">
-<h2>Late Night Hosts’ Jokes</h2>
+## Late Night Hosts’ Jokes
 <p>Lets see if we can catch (or fact check, if you will), any of the late night hosts’ jokes about the Mueller Report.</p>
-<div id="trevor-noah" class="section level3">
-<h3>Trevor Noah</h3>
+### Trevor Noah
 {{< video https://www.youtube.com/embed/pVbwZg8rM2c >}}
 <pre class="r"><code>content %&gt;% 
   arrange(compound) %&gt;% 
@@ -328,9 +267,7 @@ def get_related_lines(query):
 ##  9 &quot;guilty, pursuant to a single-count information , to identity fr…   183    15
 ## 10 &quot;difficult to argue that hacked emails in electronic form, which…   184    27</code></pre>
 <p>The joke at around 34secs into the video can be clearly seen above as the 2nd highest polarized line in the report (page 290, line 20).</p>
-</div>
-<div id="stephen-colbert" class="section level3">
-<h3>Stephen Colbert</h3>
+### Stephen Colbert
 {{< video https://www.youtube.com/embed/7MursWMNONo >}}
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;olc&quot;)) %&gt;% 
@@ -349,9 +286,7 @@ def get_related_lines(query):
 ## 9 &quot;executive officials).&quot;                                              382    18</code></pre>
 <p>The discussion about OLC from the video above at around 9min48secs can be seen in multiple instances as per our search engine, notably here (page 390) -
 “Impeachment is also a drastic and rarely invoked remedy, and Congress is not restricted to relying only on impeachment, rather than making criminal law applicable to a former President, as OLC has recognized.”</p>
-</div>
-<div id="jimmy-fallon" class="section level3">
-<h3>Jimmy Fallon</h3>
+### Jimmy Fallon
 {{< video https://www.youtube.com/embed/TJZf0JIdqqU >}}
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;crazy&quot;)) %&gt;% 
@@ -373,9 +308,7 @@ def get_related_lines(query):
 resign. McGahn recalled that, after speaking with his attorney and given the nature of the
 President’s request, he decided not to share details of the President’s request with other White
 House staff.”</p>
-</div>
-<div id="jimmy-kimmel" class="section level3">
-<h3>Jimmy Kimmel</h3>
+### Jimmy Kimmel
 {{< video https://www.youtube.com/embed/NB7ZMczCXEM >}}
 <pre class="r"><code>content %&gt;% 
   slice(get_related_lines(&quot;election interference&quot;)) %&gt;% 
@@ -394,19 +327,12 @@ House staff.”</p>
 ## 9 rosenstein, rod         deput y attorney general (apr. 20 17 - pr…   409    13</code></pre>
 <p>The discussion at around 50secs into the video can be obtained from the above search query, from page 13 -
 “Although the investigation established that the Russian government perceived it would benefit from a Trump presidency and worked to secure that outcome, and that the Campaign expected it would benefit electorally from information stolen and released through Russian efforts, the investigation did not establish that members of the Trump Campaign conspired or coordinated with the Russian government in its election interference activities.”</p>
-</div>
-</div>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>Looks like all the above tools can be pretty handy in doing a quick and thorough investigation of a large document in a very small amount of time (and its pretty fun too!)</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ol style="list-style-type: decimal">
 <li><a href="https://www.kaggle.com/paultimothymooney/mueller-report">Kaggle data reference</a></li>
 <li><a href="https://www.tidytextmining.com/">Text Mining with R by Julia Silge &amp; David Robinson</a></li>
 <li><a href="https://www.data-to-viz.com/">Visualization reference</a></li>
 <li><a href="https://towardsdatascience.com/how-i-used-machine-learning-to-classify-emails-and-turn-them-into-insights-efed37c1e66">Enron Email Analysis by Anthony Dm.</a></li>
 </ol>
-</div>

--- a/posts/2019-05-07-india-general-elections-2019-analysis.qmd
+++ b/posts/2019-05-07-india-general-elections-2019-analysis.qmd
@@ -24,19 +24,10 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#project-summary">Project Summary</a></li>
-<li><a href="#project-goals">Project Goals</a></li>
-</ul>
-</div>
 
-<div id="project-summary" class="section level1">
-<h1>Project Summary</h1>
+# Project Summary
 <p>With a whole lot of buzz in India (and world) about the 2019 General Elections in India, I thought it would be a good idea to do some election analysis of these pivotal elections in India’s history. I’ll start with analyzing the 2019 Election Manifestos of the 2 biggest political parties in India, the <a href="https://www.bjp.org">Bhartiya Janta Party</a> and the <a href="https://www.inc.in">Indian National Congress</a>.</p>
-</div>
-<div id="project-goals" class="section level1">
-<h1>Project Goals</h1>
+# Project Goals
 <ol style="list-style-type: decimal">
 <li><p>Data collection and cleaning for the election manifestos of the 2 parties.</p></li>
 <li><p>Take a deep dive into the following 6 crucial sections of these manifestos for these elections -</p></li>
@@ -59,4 +50,3 @@ freeze: true
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security/">Part 6 - National Security</a></li>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc/">Part 7 - Education, Healthcare and Miscellaneous</a></li>
 </ol>
-</div>

--- a/posts/2019-05-08-india-elections-2019-bjp-vs-congress-manifestos-analysis.qmd
+++ b/posts/2019-05-08-india-elections-2019-bjp-vs-congress-manifestos-analysis.qmd
@@ -33,32 +33,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#downloading-manifestos">Downloading Manifestos</a></li>
-<li><a href="#cleaning">Cleaning</a><ul>
-<li><a href="#page-range">Page range</a></li>
-<li><a href="#text-na">Text NA</a></li>
-<li><a href="#normalize">Normalize</a></li>
-</ul></li>
-<li><a href="#export-data">Export Data</a></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 1, I’ll collect and clean data and setup the ground work for the project.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -75,9 +55,7 @@ library(ggraph)
 
 theme_set(theme_light())
 use_python(&quot;~/anaconda3/bin/python&quot;)</code></pre>
-</div>
-<div id="downloading-manifestos" class="section level2">
-<h2>Downloading Manifestos</h2>
+## Downloading Manifestos
 <p>BJP’s Manifesto available at their website - <a href="https://www.bjp.org/manifestoPDF/BJP-Election-english-2019.pdf">bjp.org</a></p>
 <pre class="r"><code>bjp_txt &lt;- pdf_text(&quot;~/Downloads/BJP-Election-english-2019.pdf&quot;)
 
@@ -116,48 +94,34 @@ congress %&gt;%
 ## $ page &lt;int&gt; 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2…
 ## $ line &lt;int&gt; 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1…
 ## $ text &lt;chr&gt; &quot;CONGRESS&quot;, &quot;WILL&quot;, &quot;DELIVER&quot;, &quot;      MANIFESTO&quot;, &quot;      LOK SAB…</code></pre>
-</div>
-<div id="cleaning" class="section level2">
-<h2>Cleaning</h2>
-<div id="page-range" class="section level3">
-<h3>Page range</h3>
+## Cleaning
+### Page range
 <p>As we see from the 2 documents, first few pages contain Title and Index of the manifestos, and then moves on to the notes from the Party Leaders. The actual plans for development and work starts from page 11 in BJP’s manifesto and page 7 in Congress’. Filtering out all the other pages for exploration</p>
 <pre class="r"><code>bjp %&gt;% 
   filter(page &gt;= 11) -&gt; bjp_content</code></pre>
 <pre class="r"><code>congress %&gt;% 
   filter(page &gt;= 7) -&gt; congress_content</code></pre>
-</div>
-<div id="text-na" class="section level3">
-<h3>Text NA</h3>
+### Text NA
 <p>Dropping all the rows where we dont have any text.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(!is.na(text)) -&gt; bjp_content
 congress_content %&gt;% 
   filter(!is.na(text)) -&gt; congress_content</code></pre>
-</div>
-<div id="normalize" class="section level3">
-<h3>Normalize</h3>
+### Normalize
 <p>Normalizing text lines.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   unnest_tokens(text, text, token = &quot;lines&quot;) -&gt; bjp_content
 congress_content %&gt;% 
   unnest_tokens(text, text, token = &quot;lines&quot;) -&gt; congress_content</code></pre>
 <p>I’ll take a deep dive into individual topics of the manifestos in separate blog posts. For now, I will export our cleaned and normalized data for future analysis.</p>
-</div>
-</div>
-<div id="export-data" class="section level2">
-<h2>Export Data</h2>
+## Export Data
 <pre class="r"><code>bjp_content %&gt;% 
   write_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content %&gt;% 
   write_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
 <p>Stay Tuned!</p>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth/">Part 2 Economic Growth</a></li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth.qmd
+++ b/posts/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth.qmd
@@ -34,33 +34,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#read-cleaned-data">Read cleaned data</a></li>
-<li><a href="#economic-growth">Economic Growth</a></li>
-<li><a href="#most-popular-words">Most Popular Words</a></li>
-<li><a href="#common-correlated-words">Common correlated words</a></li>
-<li><a href="#basic-search-engine">Basic Search Engine</a><ul>
-<li><a href="#common-popular-words-with-both-bjp-congress">Common Popular Words with both BJP &amp; Congress</a></li>
-<li><a href="#unique-popular-words-with-bjp-congress">Unique popular words with BJP &amp; Congress</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 2, I’ll explore the Economic Growth discussions in both manifestos.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -77,14 +56,10 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="read-cleaned-data" class="section level2">
-<h2>Read cleaned data</h2>
+## Read cleaned data
 <pre class="r"><code>bjp_content &lt;- read_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
-</div>
-<div id="economic-growth" class="section level2">
-<h2>Economic Growth</h2>
+## Economic Growth
 <p>This topic is covered in congress’ manifesto from Pages 9 to 13 of the pdf and in that of bjp’s from pages 13 to 20.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(page &gt;=13,
@@ -93,9 +68,7 @@ congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_mani
 congress_content %&gt;% 
   filter(page &gt;=9,
          page &lt;= 13) -&gt; congress_content</code></pre>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most Popular Words</h2>
+## Most Popular Words
 <pre class="r"><code>plot_most_popular_words &lt;- function(df, 
                                     min_count = 15,
                                     stop_words_list = stop_words) {
@@ -141,9 +114,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))</code></pre>
 <p><img src="/post/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth_files/figure-html/unnamed-chunk-6-1.png" width="1344" /></p>
-</div>
-<div id="common-correlated-words" class="section level2">
-<h2>Common correlated words</h2>
+## Common correlated words
 <pre class="r"><code>plot_common_correlated_words &lt;- function(df,
                                          counts_quantile = 0.7,
                                          correlation_threshold = 0.25,
@@ -187,9 +158,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))</code></pre>
 <p><img src="/post/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth_files/figure-html/unnamed-chunk-8-1.png" width="1152" /></p>
-</div>
-<div id="basic-search-engine" class="section level2">
-<h2>Basic Search Engine</h2>
+## Basic Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -214,8 +183,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="common-popular-words-with-both-bjp-congress" class="section level3">
-<h3>Common Popular Words with both BJP &amp; Congress</h3>
+### Common Popular Words with both BJP &amp; Congress
 <p>As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto for economy growth is “farmers”. Lets see, what each of them have planned for our farmers. First, BJP.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;farmer&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -258,9 +226,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <blockquote>
 <p>Congress promises to establish a permanent National Commission on Agricultural Devel- opment and Planning consisting of farmers, agricultural scientists and agricultural economists to examine and advise the government on how to make agriculture viable, competitive and remuner- ative. The recommendations of the Commission shall be ordinarily binding on the government. The Commission will subsume the existing Commission for Agricultural Costs and Prices and recommend appropriate minimum support prices.</p>
 </blockquote>
-</div>
-<div id="unique-popular-words-with-bjp-congress" class="section level3">
-<h3>Unique popular words with BJP &amp; Congress</h3>
+### Unique popular words with BJP &amp; Congress
 <p>One of the popular words that seems curious from BJP’s manifesto is “technology”. Let’s see what BJP has planned for the use of technology for economic growth.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;technology&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -307,15 +273,10 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 </blockquote>
 <p>With all the above analysis, we have developed some idea about the economic growth plans of the 2 parties. In the next post, I’ll do a similar analysis for employment and opportunites proposals of them.</p>
 <p>Stay Tuned!</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-vs-congress-manifestos-analysis/">Part 1 - Data Collection and Cleaning</a><br />
 </li>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities/">Part 3 - Employment and Opportunities</a></li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
+++ b/posts/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
@@ -35,33 +35,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#read-cleaned-data">Read cleaned data</a></li>
-<li><a href="#employment-and-opportunities">Employment and Opportunities</a></li>
-<li><a href="#most-popular-words">Most Popular Words</a></li>
-<li><a href="#common-correlated-words">Common correlated words</a></li>
-<li><a href="#basic-search-engine">Basic Search Engine</a><ul>
-<li><a href="#common-popular-words-with-both-bjp-congress">Common Popular Words with both BJP &amp; Congress</a></li>
-<li><a href="#unique-popular-words-with-bjp-congress">Unique popular words with BJP &amp; Congress</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 3, I’ll explore the Employment and opportunities discussions in both manifestos.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -78,23 +57,17 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="read-cleaned-data" class="section level2">
-<h2>Read cleaned data</h2>
+## Read cleaned data
 <pre class="r"><code>bjp_content &lt;- read_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
-</div>
-<div id="employment-and-opportunities" class="section level2">
-<h2>Employment and Opportunities</h2>
+## Employment and Opportunities
 <p>This topic is covered congress’ manifesto from Pages 6 to 8 of the pdf and in that of bjp’s from pages 20 to 22 and 27 to 28.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(between(page, 20, 22) | between(page, 27, 28)) -&gt; bjp_content
 
 congress_content %&gt;% 
   filter(between(page, 6, 8)) -&gt; congress_content</code></pre>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most Popular Words</h2>
+## Most Popular Words
 <pre class="r"><code>plot_most_popular_words &lt;- function(df, 
                                     min_count = 15,
                                     stop_words_list = stop_words) {
@@ -140,9 +113,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))</code></pre>
 <p><img src="/post/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-6-1.png" width="1344" /></p>
-</div>
-<div id="common-correlated-words" class="section level2">
-<h2>Common correlated words</h2>
+## Common correlated words
 <pre class="r"><code>plot_common_correlated_words &lt;- function(df,
                                          counts_quantile = 0.7,
                                          correlation_threshold = 0.25,
@@ -186,9 +157,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))</code></pre>
 <p><img src="/post/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-8-1.png" width="1152" /></p>
-</div>
-<div id="basic-search-engine" class="section level2">
-<h2>Basic Search Engine</h2>
+## Basic Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -213,8 +182,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="common-popular-words-with-both-bjp-congress" class="section level3">
-<h3>Common Popular Words with both BJP &amp; Congress</h3>
+### Common Popular Words with both BJP &amp; Congress
 <p>As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto for Employment and Opportunities is “electricity”. Lets see, what each of them have planned for that. First, BJP.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;electricity&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -258,9 +226,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <blockquote>
 <p>Congress promises to enhance availability of, and access to, electricity in rural areas by encour- aging investment in off-grid renewable power generation with ownership and revenues vesting in local bodies. Every village and every home will be electrified in the true sense. In the long term, we aim to substitute LPG used in homes by electricity and solar energy.</p>
 </blockquote>
-</div>
-<div id="unique-popular-words-with-bjp-congress" class="section level3">
-<h3>Unique popular words with BJP &amp; Congress</h3>
+### Unique popular words with BJP &amp; Congress
 <p>One of the popular words that seems curious from BJP’s manifesto is “youth”. Let’s see what BJP has planned for the youth employment opportunities.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;youth&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -303,15 +269,10 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <p>A surprisingly large amount of mention of the word “business”/“businesses” in this section of Congress’ manifesto.</p>
 <p>With all the above analysis, we have developed some idea about the Employment and Opportunities plans of the 2 parties. In the next post, I’ll do a similar analysis for Anti-Corruption and Good Governance proposals by them.</p>
 <p>Stay Tuned!</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth/">Part 2 - Economic Growth</a><br />
 </li>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-4-anti-corruption-and-good-governance/">Part 4 - Anti-Corruption and Good Governance</a></li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
+++ b/posts/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
@@ -35,33 +35,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#read-cleaned-data">Read cleaned data</a></li>
-<li><a href="#anti-corruption-and-good-governance">Anti-Corruption and Good Governance</a></li>
-<li><a href="#most-popular-words">Most Popular Words</a></li>
-<li><a href="#common-correlated-words">Common correlated words</a></li>
-<li><a href="#basic-search-engine">Basic Search Engine</a><ul>
-<li><a href="#common-popular-words-with-both-bjp-congress">Common Popular Words with both BJP &amp; Congress</a></li>
-<li><a href="#unique-popular-words-with-bjp-congress">Unique popular words with BJP &amp; Congress</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 4, I’ll explore the Anti-corruption and Good Governance discussions in both manifestos.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -78,23 +57,17 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="read-cleaned-data" class="section level2">
-<h2>Read cleaned data</h2>
+## Read cleaned data
 <pre class="r"><code>bjp_content &lt;- read_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
-</div>
-<div id="anti-corruption-and-good-governance" class="section level2">
-<h2>Anti-Corruption and Good Governance</h2>
+## Anti-Corruption and Good Governance
 <p>This topic is covered congress’ manifesto from Pages 17 to 19 of the pdf and in that of bjp’s from pages 24 to 26.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(between(page, 24, 26)) -&gt; bjp_content
 
 congress_content %&gt;% 
   filter(between(page, 17, 19)) -&gt; congress_content</code></pre>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most Popular Words</h2>
+## Most Popular Words
 <pre class="r"><code>plot_most_popular_words &lt;- function(df, 
                                     min_count = 15,
                                     stop_words_list = stop_words) {
@@ -140,9 +113,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))</code></pre>
 <p><img src="/post/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-6-1.png" width="1344" /></p>
-</div>
-<div id="common-correlated-words" class="section level2">
-<h2>Common correlated words</h2>
+## Common correlated words
 <pre class="r"><code>plot_common_correlated_words &lt;- function(df,
                                          counts_quantile = 0.7,
                                          correlation_threshold = 0.25,
@@ -186,9 +157,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))</code></pre>
 <p><img src="/post/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-8-1.png" width="1152" /></p>
-</div>
-<div id="basic-search-engine" class="section level2">
-<h2>Basic Search Engine</h2>
+## Basic Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -213,8 +182,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="common-popular-words-with-both-bjp-congress" class="section level3">
-<h3>Common Popular Words with both BJP &amp; Congress</h3>
+### Common Popular Words with both BJP &amp; Congress
 <p>As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto is “police”. Lets see, what each of them have planned for our police force. First, BJP.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;police&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -259,9 +227,7 @@ b. Decentralise the police force in the State and to involve the community in th
 police force.
 c. Cause investigations into cases of communal riots, lynchings and gang rapes by a special wing of the State police under the direct command of the State Headquarters of the police.</p>
 </blockquote>
-</div>
-<div id="unique-popular-words-with-bjp-congress" class="section level3">
-<h3>Unique popular words with BJP &amp; Congress</h3>
+### Unique popular words with BJP &amp; Congress
 <p>One of the popular words that seems curious from BJP’s manifesto is “forest”.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;forest&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -303,15 +269,10 @@ c. Cause investigations into cases of communal riots, lynchings and gang rapes 
 </blockquote>
 <p>With all the above analysis, we have developed some idea about the Anti-corruption and Good Governance ideologies of the 2 parties. In the next post, I’ll do a similar analysis for Inclusion and Diversity proposals by them.</p>
 <p>Stay Tuned!</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities/">Part 3 - Employment and Opportunities</a><br />
 </li>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity/">Part 5 - Inclusion and Diversity</a></li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity.qmd
+++ b/posts/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity.qmd
@@ -35,33 +35,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#read-cleaned-data">Read cleaned data</a></li>
-<li><a href="#inclusion-and-diversity">Inclusion and Diversity</a></li>
-<li><a href="#most-popular-words">Most Popular Words</a></li>
-<li><a href="#common-correlated-words">Common correlated words</a></li>
-<li><a href="#basic-search-engine">Basic Search Engine</a><ul>
-<li><a href="#common-popular-words-with-both-bjp-congress">Common Popular Words with both BJP &amp; Congress</a></li>
-<li><a href="#unique-popular-words-with-bjp-congress">Unique popular words with BJP &amp; Congress</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 5, I’ll explore the Inclusion and Diversity discussions in both manifestos.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -78,23 +57,17 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="read-cleaned-data" class="section level2">
-<h2>Read cleaned data</h2>
+## Read cleaned data
 <pre class="r"><code>bjp_content &lt;- read_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
-</div>
-<div id="inclusion-and-diversity" class="section level2">
-<h2>Inclusion and Diversity</h2>
+## Inclusion and Diversity
 <p>This topic is covered congress’ manifesto from Pages 20 to 23 of the pdf and in that of bjp’s from pages 31 to 35.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(between(page, 31, 35)) -&gt; bjp_content
 
 congress_content %&gt;% 
   filter(between(page, 20, 23)) -&gt; congress_content</code></pre>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most Popular Words</h2>
+## Most Popular Words
 <pre class="r"><code>plot_most_popular_words &lt;- function(df, 
                                     min_count = 15,
                                     stop_words_list = stop_words) {
@@ -140,9 +113,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))</code></pre>
 <p><img src="/post/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity_files/figure-html/unnamed-chunk-6-1.png" width="1344" /></p>
-</div>
-<div id="common-correlated-words" class="section level2">
-<h2>Common correlated words</h2>
+## Common correlated words
 <pre class="r"><code>plot_common_correlated_words &lt;- function(df,
                                          counts_quantile = 0.7,
                                          correlation_threshold = 0.25,
@@ -186,9 +157,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))</code></pre>
 <p><img src="/post/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity_files/figure-html/unnamed-chunk-8-1.png" width="1152" /></p>
-</div>
-<div id="basic-search-engine" class="section level2">
-<h2>Basic Search Engine</h2>
+## Basic Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -213,8 +182,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="common-popular-words-with-both-bjp-congress" class="section level3">
-<h3>Common Popular Words with both BJP &amp; Congress</h3>
+### Common Popular Words with both BJP &amp; Congress
 <p>As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto is “women”. Lets see, what each of them have planned for women in our country. First, BJP.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;women&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -254,9 +222,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <blockquote>
 <p>We will stipulate that every Special Economic Zone shall have working women’s hostels and safe transport facilities to increase the participation of women in the labour force.</p>
 </blockquote>
-</div>
-<div id="unique-popular-words-with-bjp-congress" class="section level3">
-<h3>Unique popular words with BJP &amp; Congress</h3>
+### Unique popular words with BJP &amp; Congress
 <p>One of the popular words that seems curious from BJP’s manifesto is “families”.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;families&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -298,15 +264,10 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 </blockquote>
 <p>With all the above analysis, we have developed some idea about the Inclusion &amp; Diversity plans of the 2 parties. In the next post, I’ll do a similar analysis for National Security proposals by them.</p>
 <p>Stay Tuned!</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-4-anti-corruption-and-good-governance/">Part 4 - Anti-Corruption and Good Governance</a><br />
 </li>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security/">Part 6 - National Security</a></li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security.qmd
+++ b/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security.qmd
@@ -35,33 +35,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#read-cleaned-data">Read cleaned data</a></li>
-<li><a href="#national-security">National Security</a></li>
-<li><a href="#most-popular-words">Most Popular Words</a></li>
-<li><a href="#common-correlated-words">Common correlated words</a></li>
-<li><a href="#basic-search-engine">Basic Search Engine</a><ul>
-<li><a href="#common-popular-words-with-both-bjp-congress">Common Popular Words with both BJP &amp; Congress</a></li>
-<li><a href="#unique-popular-words-with-bjp-congress">Unique popular words with BJP &amp; Congress</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 6, I’ll explore the National Security discussions in both manifestos.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -78,23 +57,17 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="read-cleaned-data" class="section level2">
-<h2>Read cleaned data</h2>
+## Read cleaned data
 <pre class="r"><code>bjp_content &lt;- read_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
-</div>
-<div id="national-security" class="section level2">
-<h2>National Security</h2>
+## National Security
 <p>This topic is covered congress’ manifesto from Pages 13 to 16 of the pdf and in that of bjp’s from pages 11 to 12 and 38 to 39.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(between(page, 11, 12) | between(page, 38, 39)) -&gt; bjp_content
 
 congress_content %&gt;% 
   filter(between(page, 13, 16)) -&gt; congress_content</code></pre>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most Popular Words</h2>
+## Most Popular Words
 <pre class="r"><code>plot_most_popular_words &lt;- function(df, 
                                     min_count = 15,
                                     stop_words_list = stop_words) {
@@ -140,9 +113,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))</code></pre>
 <p><img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security_files/figure-html/unnamed-chunk-6-1.png" width="1344" /></p>
-</div>
-<div id="common-correlated-words" class="section level2">
-<h2>Common correlated words</h2>
+## Common correlated words
 <pre class="r"><code>plot_common_correlated_words &lt;- function(df,
                                          counts_quantile = 0.7,
                                          correlation_threshold = 0.25,
@@ -186,9 +157,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))</code></pre>
 <p><img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security_files/figure-html/unnamed-chunk-8-1.png" width="1152" /></p>
-</div>
-<div id="basic-search-engine" class="section level2">
-<h2>Basic Search Engine</h2>
+## Basic Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -213,8 +182,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="common-popular-words-with-both-bjp-congress" class="section level3">
-<h3>Common Popular Words with both BJP &amp; Congress</h3>
+### Common Popular Words with both BJP &amp; Congress
 <p>As we see from the plot above, one of the most popular words in both BJP and Congress’ is “terrorism”. Lets see, what each of them have planned to combat terrorism. First, BJP.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;terrorism&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -255,9 +223,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <blockquote>
 <p>The concept of national security in the 21st century has expanded beyond defence of the territory to include data security, cyber security, financial security, communication security and security of trade routes. Congress promises to evolve suitable policies to address each of these subjects.</p>
 </blockquote>
-</div>
-<div id="unique-popular-words-with-bjp-congress" class="section level3">
-<h3>Unique popular words with BJP &amp; Congress</h3>
+### Unique popular words with BJP &amp; Congress
 <p>One of the popular words that seems curious from BJP’s manifesto is “police”.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;police&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -299,15 +265,10 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 </blockquote>
 <p>With all the above analysis, we have developed some idea about the National Security goals of the 2 parties. In the next post, I’ll do a similar analysis for Education Healthcare and other miscellaneous proposals by them.</p>
 <p>Stay Tuned!</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity/">Part 5 - Inclusion and Diversity</a><br />
 </li>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc/">Part 7 - Education, Healthcare and Miscellaneous</a></li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc.qmd
+++ b/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc.qmd
@@ -35,33 +35,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#read-cleaned-data">Read cleaned data</a></li>
-<li><a href="#education-health-care-and-miscellaneous">Education, Health Care and Miscellaneous</a></li>
-<li><a href="#most-popular-words">Most Popular Words</a></li>
-<li><a href="#common-correlated-words">Common correlated words</a></li>
-<li><a href="#basic-search-engine">Basic Search Engine</a><ul>
-<li><a href="#common-popular-words-with-both-bjp-congress">Common Popular Words with both BJP &amp; Congress</a></li>
-<li><a href="#unique-popular-words-with-bjp-congress">Unique popular words with BJP &amp; Congress</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.<br />
 In this part 7, I’ll explore the Education, Health Care and other miscellaneous discussions in both manifestos.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(pdftools)
@@ -78,23 +57,17 @@ library(ggraph)
 
 theme_set(theme_light())
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="read-cleaned-data" class="section level2">
-<h2>Read cleaned data</h2>
+## Read cleaned data
 <pre class="r"><code>bjp_content &lt;- read_csv(&quot;../data/indian_election_2019/bjp_manifesto_clean.csv&quot;)
 congress_content &lt;- read_csv(&quot;../data/indian_election_2019/congress_manifesto_clean.csv&quot;)</code></pre>
-</div>
-<div id="education-health-care-and-miscellaneous" class="section level2">
-<h2>Education, Health Care and Miscellaneous</h2>
+## Education, Health Care and Miscellaneous
 <p>This topic is covered congress’ manifesto from Pages 24 to 27 of the pdf and in that of bjp’s from pages 23 and 29 to 30 and 36 to 37.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   filter(between(page, 23, 23) | between(page, 29, 30) | between(page, 36, 37)) -&gt; bjp_content
 
 congress_content %&gt;% 
   filter(between(page, 24, 27)) -&gt; congress_content</code></pre>
-</div>
-<div id="most-popular-words" class="section level2">
-<h2>Most Popular Words</h2>
+## Most Popular Words
 <pre class="r"><code>plot_most_popular_words &lt;- function(df, 
                                     min_count = 15,
                                     stop_words_list = stop_words) {
@@ -140,9 +113,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))</code></pre>
 <p><img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc_files/figure-html/unnamed-chunk-6-1.png" width="1344" /></p>
-</div>
-<div id="common-correlated-words" class="section level2">
-<h2>Common correlated words</h2>
+## Common correlated words
 <pre class="r"><code>plot_common_correlated_words &lt;- function(df,
                                          counts_quantile = 0.7,
                                          correlation_threshold = 0.25,
@@ -186,9 +157,7 @@ congress_content %&gt;%
 
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))</code></pre>
 <p><img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc_files/figure-html/unnamed-chunk-8-1.png" width="1152" /></p>
-</div>
-<div id="basic-search-engine" class="section level2">
-<h2>Basic Search Engine</h2>
+## Basic Search Engine
 <p>Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.</p>
 <pre class="python"><code>from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
@@ -213,8 +182,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
   cosine_sim = linear_kernel(vector_query, vector_train).flatten()
   return cosine_sim.argsort()[:-10:-1]</code></pre>
 <pre class="r"><code>get_related_lines &lt;- py_to_r(py$get_related_lines)</code></pre>
-<div id="common-popular-words-with-both-bjp-congress" class="section level3">
-<h3>Common Popular Words with both BJP &amp; Congress</h3>
+### Common Popular Words with both BJP &amp; Congress
 <p>As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto is “children”. Lets see, what each of them have planned for the children of our country. First, BJP.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;children&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -255,9 +223,7 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <blockquote>
 <p>Congress promises that school education from Class I to Class XII in public schools shall be compulsory and free. Suitable amendments will be made in the Right to Education Act, 2009. We will end the practice of charging special fees for different purposes in public schools.</p>
 </blockquote>
-</div>
-<div id="unique-popular-words-with-bjp-congress" class="section level3">
-<h3>Unique popular words with BJP &amp; Congress</h3>
+### Unique popular words with BJP &amp; Congress
 <p>One of the popular words that seems curious from BJP’s manifesto is “yoga”.</p>
 <pre class="r"><code>bjp_content %&gt;% 
   slice(get_related_lines(&quot;yoga&quot;, party = &quot;bjp&quot;)) %&gt;% 
@@ -300,14 +266,9 @@ def get_related_lines(query, party=&quot;bjp&quot;):
 <p>With all the above analysis, we have developed some idea about the Education, Healthcare and other miscellaneous plans of the 2 parties.</p>
 <p>With this I conclude my analysis of the manifestos of BJP and Congress for 2019 general elections. I highly encourage all my readers to make their choice carefully in these pivotal elections and even though these analyses give you a high level idea about each party, maybe try and go through the entire manifestos to make a much informed decision about your choice and ensure accountability from our governments.</p>
 <p>Let’s hope for and build a better India. All the best!</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li><a href="/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security/">Part 6 - National Security</a><br />
 </li>
 <li>For all the parts go to Project Summary Page - <a href="/2019/05/india-general-elections-2019-analysis/">India General Elections 2019 Analysis</a></li>
 </ul>
-</div>

--- a/posts/2019-06-21-christmas-bird-counts-tidytuesday.qmd
+++ b/posts/2019-06-21-christmas-bird-counts-tidytuesday.qmd
@@ -27,25 +27,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load libraries</a></li>
-<li><a href="#which-are-the-5-most-common-birds-over-years">Which are the 5 most common birds over years?</a></li>
-</ul></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Visualizing bird watching data as collected in Hamilton area of Ontario during Christmas time since 1921.</p>
 <p>Working on the weekly social data project <a href="https://github.com/rfordatascience/tidytuesday/tree/master/data/2019/2019-06-18">Tidy Tuesday</a>.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load libraries</h2>
+# Analysis
+## Load libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(lubridate)
@@ -89,9 +76,7 @@ bird_counts</code></pre>
 ##  3rd Qu.:203.8   3rd Qu.:  0.051         
 ##  Max.   :251.0   Max.   :439.024         
 ##  NA&#39;s   :3781    NA&#39;s   :3781</code></pre>
-</div>
-<div id="which-are-the-5-most-common-birds-over-years" class="section level2">
-<h2>Which are the 5 most common birds over years?</h2>
+## Which are the 5 most common birds over years?
 <pre class="r"><code>bird_counts %&gt;% 
   group_by(year) %&gt;% 
   mutate(rank = min_rank(-how_many_counted) * 1) %&gt;% 
@@ -135,5 +120,3 @@ bird_counts</code></pre>
           height = 600,
           renderer = gifski_renderer(&quot;../data/christmas_bird_counts/most_common.gif&quot;))</code></pre>
 <p><img src="/post/2019-06-21-christmas-bird-counts-tidytuesday_files/figure-html/unnamed-chunk-5-1.gif" /><!-- --></p>
-</div>
-</div>

--- a/posts/2019-07-17-music-artist-recommendation-system-project.qmd
+++ b/posts/2019-07-17-music-artist-recommendation-system-project.qmd
@@ -26,23 +26,13 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#project-summary">Project Summary</a></li>
-<li><a href="#project-goals">Project Goals</a></li>
-</ul>
-</div>
 
-<div id="project-summary" class="section level1">
-<h1>Project Summary</h1>
+# Project Summary
 <p>Recommendation systems are all around us, from Netflix’s amazing video recommender system to Amazon’s product recommendation system and many many more. I have always been curious about the science and effort that goes into building one and combining it with another one of my favorite topics, Music, would make it one of the more interesting projects that I try my hands on. Let’s see if we can build a music artist recommendation system that is similar to the ones built by Spotify or Amazon Music. I will use the <a href="https://grouplens.org/datasets/hetrec-2011/">Last.fm Dataset</a> provided by GroupLens and works towards building a music artist recommendation system.</p>
-</div>
-<div id="project-goals" class="section level1">
-<h1>Project Goals</h1>
+# Project Goals
 <ol style="list-style-type: decimal">
 <li><p>Exploratory data analysis of the Last.fm dataset.</p></li>
 <li><p>Build Content-based and Collaborative filtering based recommendation system to recommend music artists to users.</p></li>
 <li><p>Generate a hybrid recommender that combines all previously trained recommenders and provides recommendations.</p></li>
 </ol>
 <p>In the next series of posts I’ll roughly follow the above steps.</p>
-</div>

--- a/posts/2019-07-18-music-recommendation-system.qmd
+++ b/posts/2019-07-18-music-recommendation-system.qmd
@@ -30,31 +30,11 @@ freeze: true
 <link href="/rmarkdown-libs/sequences/sequences.css" rel="stylesheet" />
 <script src="/rmarkdown-libs/sunburst-binding/sunburst.js"></script>
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#obtain-data">Obtain Data</a></li>
-<li><a href="#scrub-and-explore">Scrub and Explore</a><ul>
-<li><a href="#ratings">Ratings</a></li>
-<li><a href="#friends">Friends</a></li>
-<li><a href="#metadata">Metadata</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Music Artist Recommendation System using the <a href="https://grouplens.org/datasets/hetrec-2011/">Last.fm Dataset</a>. Exploratory data analysis.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Analysis
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(tidylog)
@@ -66,9 +46,7 @@ library(htmltools)
 library(htmlwidgets)
 
 theme_set(theme_light())</code></pre>
-</div>
-<div id="obtain-data" class="section level2">
-<h2>Obtain Data</h2>
+## Obtain Data
 <pre class="r"><code>artists &lt;- read_tsv(&quot;../data/hetrec2011-lastfm-2k/artists.dat&quot;)
 tags &lt;- read_tsv(&quot;../data/hetrec2011-lastfm-2k/tags.dat&quot;)
 ratings &lt;- read_tsv(&quot;../data/hetrec2011-lastfm-2k/user_artists.dat&quot;)
@@ -107,11 +85,8 @@ user_tagged_artists &lt;- read_tsv(&quot;../data/hetrec2011-lastfm-2k/user_tagge
 ## $ userID   &lt;dbl&gt; 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, …
 ## $ artistID &lt;dbl&gt; 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, …
 ## $ weight   &lt;dbl&gt; 13883, 11690, 11351, 10300, 8983, 6152, 5955, 4616, 4337, 41…</code></pre>
-</div>
-<div id="scrub-and-explore" class="section level2">
-<h2>Scrub and Explore</h2>
-<div id="ratings" class="section level3">
-<h3>Ratings</h3>
+## Scrub and Explore
+### Ratings
 <pre class="r"><code>ratings %&gt;% 
   head()</code></pre>
 <pre><code>## # A tibble: 6 x 3
@@ -216,9 +191,7 @@ grid.arrange(p +
 ##  9 190        400
 ## 10 498        399
 ## # … with 17,622 more rows</code></pre>
-</div>
-<div id="friends" class="section level3">
-<h3>Friends</h3>
+### Friends
 <pre class="r"><code>friends %&gt;% 
   glimpse()</code></pre>
 <pre><code>## Rows: 25,434
@@ -248,9 +221,7 @@ grid.arrange(p +
 ##  9 1300      89
 ## 10 390       88
 ## # … with 1,882 more rows</code></pre>
-</div>
-<div id="metadata" class="section level3">
-<h3>Metadata</h3>
+### Metadata
 <pre class="r"><code>metadata %&gt;% 
   glimpse()</code></pre>
 <pre><code>## Rows: 186,479
@@ -372,20 +343,17 @@ metadata %&gt;%
 snb &lt;- htmlwidgets::prependContent(snb, htmltools::h2(&quot;Sunburst of most popular artists in 5 most popular tags&quot;))
 snb &lt;- htmlwidgets::prependContent(snb, htmltools::h5(&quot;Hover over to the see the artists and tags&quot;))
 snb</code></pre>
-<h2>Sunburst of most popular artists in 5 most popular tags</h2>
-<h5>Hover over to the see the artists and tags</h5>
+## Sunburst of most popular artists in 5 most popular tags
+##### Hover over to the see the artists and tags
 <div class="sunburst html-widget" id="htmlwidget-1" style="width:672px;height:480px; position:relative;">
 <div>
 <div class="sunburst-main">
 <div class="sunburst-sequence"></div>
 <div class="sunburst-chart">
 <div class="sunburst-explanation" style="visibility:hidden;"></div>
-</div>
-</div>
 <div class="sunburst-sidebar">
 <input type="checkbox" class="sunburst-togglelegend" style="visibility:hidden;">Legend</input>
 <div class="sunburst-legend" style="visibility:hidden;"></div>
-</div>
 </div>
 </div>
 <script type="application/json" data-for="htmlwidget-1">{"x":{"data":{"children":[{"name":"pop","children":[{"name":"Britney Spears","size":108,"colname":"X2"},{"name":"Lady Gaga","size":99,"colname":"X2"},{"name":"Christina Aguilera","size":83,"colname":"X2"},{"name":"Madonna","size":78,"colname":"X2"},{"name":"Katy Perry","size":68,"colname":"X2"}],"colname":"X1"},{"name":"electronic","children":[{"name":"Depeche Mode","size":68,"colname":"X2"},{"name":"Björk","size":54,"colname":"X2"},{"name":"Lady Gaga","size":51,"colname":"X2"},{"name":"Daft Punk","size":39,"colname":"X2"},{"name":"Massive Attack","size":37,"colname":"X2"}],"colname":"X1"},{"name":"rock","children":[{"name":"The Beatles","size":67,"colname":"X2"},{"name":"Muse","size":65,"colname":"X2"},{"name":"Paramore","size":58,"colname":"X2"},{"name":"U2","size":52,"colname":"X2"},{"name":"Linkin Park","size":48,"colname":"X2"},{"name":"Radiohead","size":48,"colname":"X2"}],"colname":"X1"},{"name":"alternative","children":[{"name":"Radiohead","size":64,"colname":"X2"},{"name":"Muse","size":62,"colname":"X2"},{"name":"Placebo","size":48,"colname":"X2"},{"name":"Björk","size":46,"colname":"X2"},{"name":"Paramore","size":46,"colname":"X2"}],"colname":"X1"},{"name":"indie","children":[{"name":"The Killers","size":49,"colname":"X2"},{"name":"Franz Ferdinand","size":43,"colname":"X2"},{"name":"Arctic Monkeys","size":41,"colname":"X2"},{"name":"Muse","size":39,"colname":"X2"},{"name":"Radiohead","size":39,"colname":"X2"}],"colname":"X1"}],"name":"root"},"options":{"legendOrder":null,"colors":null,"valueField":"size","percent":true,"count":false,"explanation":null,"breadcrumb":[],"legend":false,"sortFunction":null,"sumNodes":true}},"evals":[],"jsHooks":[]}</script>
@@ -393,8 +361,7 @@ snb</code></pre>
 </div>
 </div>
 </div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In this post, we</p>
 <ul>
 <li>Downloaded and merged the dataset</li>
@@ -408,11 +375,8 @@ friends %&gt;%
   write_csv(&quot;../data/hetrec2011-lastfm-2k/friends_clean.csv&quot;)
 metadata %&gt;% 
   write_csv(&quot;../data/hetrec2011-lastfm-2k/metadata_clean.csv&quot;)</code></pre>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ol style="list-style-type: decimal">
 <li><a href="https://grouplens.org/datasets/hetrec-2011/">Data reference</a></li>
 <li><a href="https://www.data-to-viz.com/">Visualization reference</a></li>
 </ol>
-</div>

--- a/posts/2019-07-19-music-artist-recommendation-system-surprise.qmd
+++ b/posts/2019-07-19-music-artist-recommendation-system-surprise.qmd
@@ -21,25 +21,11 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#modelling">Modelling</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#obtain-data">Obtain Data</a></li>
-</ul></li>
-<li><a href="#python-surprise">Python Surprise</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Music Artist Recommendation System using the <a href="https://grouplens.org/datasets/hetrec-2011/">Last.fm Dataset</a>. Recommenders using Python’s Surprise Library.</p>
-</div>
-<div id="modelling" class="section level1">
-<h1>Modelling</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Modelling
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(tidylog)
@@ -51,9 +37,7 @@ library(reticulate)
 theme_set(theme_light())
 # use_condaenv(&quot;py-portfolioV2&quot;)
 use_condaenv(&quot;stanford-nlp&quot;)</code></pre>
-</div>
-<div id="obtain-data" class="section level2">
-<h2>Obtain Data</h2>
+## Obtain Data
 <pre class="r"><code>ratings &lt;- read_csv(&quot;../data/hetrec2011-lastfm-2k/ratings_clean.csv&quot;)
 ratings %&gt;% 
   glimpse()</code></pre>
@@ -122,11 +106,7 @@ metadata %&gt;%
 ##  9 227           178
 ## 10 55            173
 ## # … with 12,513 more rows</code></pre>
-</div>
-</div>
-<div id="python-surprise" class="section level1">
-<h1>Python Surprise</h1>
+# Python Surprise
 <pre class="python"><code>import surprise
 from surprise import SVD, Dataset, Reader, accuracy
 from surprise.model_selection import cross_validate, train_test_split</code></pre>
-</div>

--- a/posts/2020-02-18-nlp-with-disaster-tweets.qmd
+++ b/posts/2020-02-18-nlp-with-disaster-tweets.qmd
@@ -25,30 +25,18 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#project-summary">Project Summary</a></li>
-<li><a href="#project-goals">Project Goals</a></li>
-<li><a href="#series">Series</a></li>
-</ul>
-</div>
 
-<div id="project-summary" class="section level1">
-<h1>Project Summary</h1>
+# Project Summary
 <p>With this project, I’ll apply and practice various NLP techniques, along with trying my hands on the <a href="https://github.com/tidymodels/tidymodels" target="_blank">tidymodels framework</a>.
 I will use the <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle for its dataset and also evaluating model performance using submissions.</p>
-</div>
-<div id="project-goals" class="section level1">
-<h1>Project Goals</h1>
+# Project Goals
 <ol style="list-style-type: decimal">
 <li><p>Apply and improve NLP skills in R &amp; Python.</p></li>
 <li><p>Learn and apply tidymodels modelling framework to do reproducible and effective science.</p></li>
 <li><p>Focus more on model explainability and relative comparison of different algorithms.</p></li>
 <li><p>Improve skills in PyTorch deep learning framework for model training and prediction.</p></li>
 </ol>
-</div>
-<div id="series" class="section level1">
-<h1>Series</h1>
+# Series
 <p>The following series of posts tackle the above project goals sequentially</p>
 <ul>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a><br />
@@ -60,4 +48,3 @@ I will use the <a href="https://www.kaggle.com/c/nlp-getting-started" target="_b
 <li>Project Part 6 - <a href="/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/" target="_blank">NLP with Disaster Tweets: Part 6 Multi Layer Perceptron</a></li>
 <li>Project Part 7 - <a href="/2020/09/nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us/" target="_blank">NLP with Disaster Tweets: Part 7 Vanilla RNN and GRU</a></li>
 </ul>
-</div>

--- a/posts/2020-02-19-nlp-with-disaster-tweets-part-1.qmd
+++ b/posts/2020-02-19-nlp-with-disaster-tweets-part-1.qmd
@@ -27,33 +27,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#read-data">Read Data</a></li>
-<li><a href="#getting-glove-embedding-for-tweet-text-and-adding-as-features">Getting glove embedding for tweet text and adding as features</a><ul>
-<li><a href="#tokenize-incoming-tweet-texts-in-the-training-data">Tokenize incoming tweet texts in the training data</a></li>
-<li><a href="#download-and-parse-glove-embeddings-into-an-embedding-matrix-for-the-tokenized-words">Download and parse glove embeddings into an embedding matrix for the tokenized words</a></li>
-<li><a href="#generate-embeddings-vector-for-tweets-text-in-training-data">Generate embeddings vector for tweets text in training data</a></li>
-<li><a href="#generate-embeddings-vector-for-tweets-text-in-test-data">Generate embeddings vector for tweets text in test data</a></li>
-<li><a href="#append-to-given-tweets-features-and-export">Append to given tweets features and export</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 1 for data preparation, I will do some basic exploration and vectorize the given tweet text into <a href="https://nlp.stanford.edu/projects/glove/" target="_blank">glove</a> embedding vectors.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Analysis
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(ggplot2)
@@ -64,9 +43,7 @@ library(keras)
 library(janitor)
 
 theme_set(theme_light())</code></pre>
-</div>
-<div id="read-data" class="section level2">
-<h2>Read Data</h2>
+## Read Data
 <pre class="r"><code>tweets &lt;- read_csv(&quot;../data/nlp_with_disaster_tweets/train.csv&quot;)
 tweets_test &lt;- read_csv(&quot;../data/nlp_with_disaster_tweets/test.csv&quot;)
 skim(tweets)</code></pre>
@@ -204,9 +181,7 @@ skim(tweets)</code></pre>
 </tr>
 </tbody>
 </table>
-</div>
-<div id="getting-glove-embedding-for-tweet-text-and-adding-as-features" class="section level2">
-<h2>Getting glove embedding for tweet text and adding as features</h2>
+## Getting glove embedding for tweet text and adding as features
 <p>The simple workflow for vectorizing tweet text into glove embeddings is as follows -</p>
 <ol style="list-style-type: decimal">
 <li>Tokenize incoming tweet texts in the training data.<br />
@@ -219,8 +194,7 @@ skim(tweets)</code></pre>
 </li>
 <li>Append to given tweets features and export.</li>
 </ol>
-<div id="tokenize-incoming-tweet-texts-in-the-training-data" class="section level3">
-<h3>Tokenize incoming tweet texts in the training data</h3>
+### Tokenize incoming tweet texts in the training data
 <p>Using keras’ text_tokenizer to tokenize the text in tweets dataset.</p>
 <pre class="r"><code>text_tokenizer() %&gt;% 
   fit_text_tokenizer(tweets$text) -&gt; tokenizer
@@ -244,9 +218,7 @@ print(maxlen)</code></pre>
 str(padded_sequences)</code></pre>
 <pre><code>##  int [1:7613, 1:33] 0 0 0 0 0 0 0 0 0 0 ...</code></pre>
 <p>Like we see above, for all the 7,613 tweets in the training data we have created a tokenized sequence of 33 elements each.</p>
-</div>
-<div id="download-and-parse-glove-embeddings-into-an-embedding-matrix-for-the-tokenized-words" class="section level3">
-<h3>Download and parse glove embeddings into an embedding matrix for the tokenized words</h3>
+### Download and parse glove embeddings into an embedding matrix for the tokenized words
 <p>Downloaded the pre-trained glove embeddings trained on 2 billion tweets from Stanford’s NLP projects page on <a href="https://nlp.stanford.edu/projects/glove/">Glove</a> and borrowing the code for parsing and generating glove embedding matrix from my <a href="https://adityamangal410.github.io/deepSentimentR/reference/index.html">deepSentimentR</a> package.</p>
 <pre class="r"><code>parse_glove_embeddings &lt;- function(file_path) {
   lines &lt;- readLines(file_path)
@@ -288,9 +260,7 @@ saveRDS(embedding_matrix, &quot;../data/nlp_with_disaster_tweets/embedding_matri
 str(embedding_matrix)</code></pre>
 <pre><code>##  num [1:22701, 1:25] 0 0.7864 0.4186 0.7086 -0.0102 ...</code></pre>
 <p>Using only 25 dimensional embedding in order to keep the computations fast, we have created an embedding matrix which holds the 25 dimension values for the most popular 22700 words in our tweets text data.</p>
-</div>
-<div id="generate-embeddings-vector-for-tweets-text-in-training-data" class="section level3">
-<h3>Generate embeddings vector for tweets text in training data</h3>
+### Generate embeddings vector for tweets text in training data
 <p>Using the keras modelling framework to generate embeddings for the given training data. We basically create a simple sequential model with one embedding layer whose weights we will freeze based on our embedding matrix created above, and a flattening layer that will flatten the output into a 2D matrix of dimensions (7613, 33x25).</p>
 <pre class="r"><code>keras_model_sequential() %&gt;% 
   layer_embedding(input_dim = num_words, output_dim = embedding_dim, 
@@ -308,9 +278,7 @@ model_embedding %&gt;%
 str(tweets_embeddings)</code></pre>
 <pre><code>##  num [1:7613, 1:825] 0 0 0 0 0 0 0 0 0 0 ...</code></pre>
 <p>For each of the 7,613 padded tweet sequences of upto max length 33, we use the keras model to “predict” and populate the embedding for each of those 33 words in the sequence and susequently flatten those to create a single feature vector of 33x25=825 dimensions.</p>
-</div>
-<div id="generate-embeddings-vector-for-tweets-text-in-test-data" class="section level3">
-<h3>Generate embeddings vector for tweets text in test data</h3>
+### Generate embeddings vector for tweets text in test data
 <p>Using the similar approach as above (i.e. tokenize, pad and vectorize using glove embeddings) on the test data, to generate similar embedding vector for text in the tweets test data. Note that, we use the previously fit text tokenizer on the train data to tokenize the test data.</p>
 <pre class="r"><code>sequences_test &lt;- texts_to_sequences(tokenizer, tweets_test$text)</code></pre>
 <pre class="r"><code>pad_sequences(sequences_test, maxlen = maxlen) -&gt; padded_sequences_test
@@ -321,9 +289,7 @@ model_embedding %&gt;%
 str(tweets_embeddings_test)</code></pre>
 <pre><code>##  num [1:3263, 1:825] 0 0 0 0 0 0 0 0 0 0 ...</code></pre>
 <p>We similarly get 825 embedding dimensions for 3,263 tweets in the test data.</p>
-</div>
-<div id="append-to-given-tweets-features-and-export" class="section level3">
-<h3>Append to given tweets features and export</h3>
+### Append to given tweets features and export
 <pre class="r"><code>tweets %&gt;% 
   bind_cols(as_tibble(tweets_embeddings)) %&gt;% 
   clean_names() -&gt; tweets_proc
@@ -334,14 +300,9 @@ tweets_test %&gt;%
 <pre class="r"><code>saveRDS(tweets_proc, &quot;../data/nlp_with_disaster_tweets/tweets_proc.rds&quot;)
 saveRDS(tweets_test_proc, &quot;../data/nlp_with_disaster_tweets/tweets_test_proc.rds&quot;)</code></pre>
 <p>Exporting the appended feature set will help us work on this dataset for modelling. I will cover the modelling using the tidymodels framework in my upcoming posts.</p>
-</div>
-</div>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>GloVe: Global Vectors for Word Representation - <a href="https://nlp.stanford.edu/projects/glove/" target="_blank">Stanford NLP Glove Project</a></li>
 <li>DeepSentimentR package - <a href="https://adityamangal410.github.io/deepSentimentR/index.html" target="_blank">deepSentimentR</a></li>
 </ul>
-</div>

--- a/posts/2020-02-20-nlp-with-disaster-tweets-part-2-nearest-neighbor-models.qmd
+++ b/posts/2020-02-20-nlp-with-disaster-tweets-part-2-nearest-neighbor-models.qmd
@@ -27,35 +27,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#loading-processed-data-from-previous-part">Loading processed data from previous part</a></li>
-<li><a href="#feature-preprocessing-and-engineering">Feature preprocessing and engineering</a><ul>
-<li><a href="#split-data">Split data</a></li>
-<li><a href="#preparation-recipe">Preparation Recipe</a></li>
-</ul></li>
-<li><a href="#modelling">Modelling</a><ul>
-<li><a href="#baseline-model">Baseline model</a></li>
-<li><a href="#k-nearest-neighbor-model">K-Nearest Neighbor model</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 2 for Nearest Neighbor Modelling, I will use the processed data generated in <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">Part 1</a> to train nearest neighbor models in order to predict if a tweet is about a real disaster or not using the tidymodels framework.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Analysis
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(ggplot2)
@@ -63,9 +40,7 @@ library(tidymodels)
 library(silgelib)
 
 theme_set(theme_plex())</code></pre>
-</div>
-<div id="loading-processed-data-from-previous-part" class="section level2">
-<h2>Loading processed data from previous part</h2>
+## Loading processed data from previous part
 <pre class="r"><code>tweets &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_proc.rds&quot;)
 tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_proc.rds&quot;)</code></pre>
 <pre class="r"><code>tweets %&gt;% 
@@ -74,9 +49,7 @@ tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_pr
 <pre class="r"><code>tweets_final %&gt;% 
   dim</code></pre>
 <pre><code>## [1] 3263  829</code></pre>
-</div>
-<div id="feature-preprocessing-and-engineering" class="section level2">
-<h2>Feature preprocessing and engineering</h2>
+## Feature preprocessing and engineering
 <pre class="r"><code>tweets %&gt;% 
   mutate(target = as.factor(target),
          id = as.character(id)) -&gt; tweets</code></pre>
@@ -87,8 +60,7 @@ tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_pr
 ##   &lt;fct&gt;  &lt;int&gt;
 ## 1 0       4342
 ## 2 1       3271</code></pre>
-<div id="split-data" class="section level3">
-<h3>Split data</h3>
+### Split data
 <p>Splitting the data into 3 sets. A test set of 10% data, a cross validation set of 20% data and a training set of 70% data. Training and validation sets will be used for training, tuning and validating performance of models and comparing among them. Test set will only be used for final estimation of the model performance on unknown data.</p>
 <pre class="r"><code>set.seed(42)
 tweets_split &lt;- initial_split(tweets, prop = 0.1, strata = target)
@@ -106,9 +78,7 @@ tweets_cv &lt;- testing(tweets_split)</code></pre>
 <pre><code>## [1] 1522  830</code></pre>
 <pre class="r"><code>dim(tweets_test)</code></pre>
 <pre><code>## [1] 763 830</code></pre>
-</div>
-<div id="preparation-recipe" class="section level3">
-<h3>Preparation Recipe</h3>
+### Preparation Recipe
 <p>I will use the recipe package from tidymodels to generate a recipe for data preprocessing and feature engineering.</p>
 <pre class="r"><code>recipe(target ~ ., data = tweets_train) %&gt;% 
   update_role(id, new_role = &quot;ID&quot;) %&gt;% 
@@ -140,12 +110,8 @@ tweets_cv &lt;- testing(tweets_split)</code></pre>
 <pre class="r"><code>tweets_prep &lt;- tweets_recipe %&gt;% 
   prep(training = tweets_train, 
        strings_as_factors = FALSE)</code></pre>
-</div>
-</div>
-<div id="modelling" class="section level2">
-<h2>Modelling</h2>
-<div id="baseline-model" class="section level3">
-<h3>Baseline model</h3>
+## Modelling
+### Baseline model
 <p>I will first create a baseline model to beat. In this case, we can predict randomly in the ratio of target counts and evaluate the model performance accordingly.</p>
 <pre class="r"><code>tweets_prep %&gt;% 
   juice() %&gt;% 
@@ -206,12 +172,9 @@ tweets_prep %&gt;%
                                    prob = probs, replace = T))) %&gt;% 
   select(id, target) %&gt;% 
   write_csv(&quot;../data/nlp_with_disaster_tweets/submissions/baseline_cvf_57_testf_57.csv&quot;)</code></pre>
-</div>
-<div id="k-nearest-neighbor-model" class="section level3">
-<h3>K-Nearest Neighbor model</h3>
+### K-Nearest Neighbor model
 <p>Let’s build a basic KNN model with some default number of neighbors to see how the modelling is done in this framework and checkout how the modelling output looks like.</p>
-<div id="basic" class="section level4">
-<h4>Basic</h4>
+#### Basic
 <pre class="r"><code>knn_spec &lt;- nearest_neighbor(neighbors = 3) %&gt;% 
   set_engine(&quot;kknn&quot;) %&gt;% 
   set_mode(&quot;classification&quot;)
@@ -232,9 +195,7 @@ wf_fit$fit$MISCLASS</code></pre>
 ## 3 0.3521021</code></pre>
 <p>The above shows a simple K-nearest neighbors model using the “kknn” engine. Gives about 0.3521021 of minimal misclassification.
 Let’s try and tune the number of neighbors (k) and see if we can interpret the underlying problem space.</p>
-</div>
-<div id="tuning-number-of-neighbors" class="section level4">
-<h4>Tuning number of neighbors</h4>
+#### Tuning number of neighbors
 <p>Using 5-fold cross validation and values of K going from 1 to 100.</p>
 <pre class="r"><code>set.seed(1234)
 folds &lt;- vfold_cv(tweets_train, strata = target, v = 5, repeats = 1)
@@ -317,21 +278,13 @@ knn_last_fit %&gt;%
 ## 2 f_meas   binary         0.756
 ## 3 roc_auc  binary         0.687</code></pre>
 <p>Our final fit knn model with K=25 gives an f1-score of 0.7560538, which is much higher than our baseline model on the same CV dataset.</p>
-</div>
-</div>
-</div>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>We can hence learn quite a few things about our underlying problem space by using this basic modelling algorithm K-nearest neighbors and use our learning in further model selection and tuning and also generate a fairly robust model that predicts quite effectively as compared to the baseline model.<br />
 Also, this tidymodels framework provides a good modelling structure which can be easily reproduced and used to train a variety of models. In the next part of this series, I will work on another classic modelling algorithm, Lasso Regression, where we will also see if we can identify if there any of these features are much more important than the others and if our 2 custom features are useful.</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a></li>
 <li>Lasso Regression using <a href="https://juliasilge.com/blog/lasso-the-office/" target="_blank">Tidymodels by Julia Silge</a>.</li>
 <li>Introduction to Statistical Learning - <a href="https://www.amazon.com/Introduction-Statistical-Learning-Applications-Statistics/dp/1461471370" target="_blank">Book</a></li>
 </ul>
-</div>

--- a/posts/2020-04-06-nlp-with-disaster-tweets-part-3-linear-models.qmd
+++ b/posts/2020-04-06-nlp-with-disaster-tweets-part-3-linear-models.qmd
@@ -27,32 +27,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#loading-processed-data-from-previous-part">Loading processed data from previous part</a></li>
-<li><a href="#feature-preprocessing-and-engineering">Feature preprocessing and engineering</a></li>
-<li><a href="#modelling">Modelling</a><ul>
-<li><a href="#lasso-regression-using-glmnet">Lasso Regression using glmnet</a></li>
-</ul></li>
-<li><a href="#model-calibration">Model Calibration</a></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 3 for Linear Modelling, I will use the processed data generated in <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">Part 1</a> to train logistic regression based model with regularization in order to predict if a tweet is about a real disaster or not using the tidymodels framework. Following up from the previous <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a> about Nearest Neighbors model, I will do a comparative study among these 2 modelling algorithms.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Analysis
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(ggplot2)
@@ -62,9 +42,7 @@ library(vip)
 library(silgelib)
 
 theme_set(theme_plex())</code></pre>
-</div>
-<div id="loading-processed-data-from-previous-part" class="section level2">
-<h2>Loading processed data from previous part</h2>
+## Loading processed data from previous part
 <pre class="r"><code>tweets &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_proc.rds&quot;)
 tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_proc.rds&quot;)</code></pre>
 <pre class="r"><code>tweets %&gt;% 
@@ -73,9 +51,7 @@ tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_pr
 <pre class="r"><code>tweets_final %&gt;% 
   dim</code></pre>
 <pre><code>## [1] 3263  829</code></pre>
-</div>
-<div id="feature-preprocessing-and-engineering" class="section level2">
-<h2>Feature preprocessing and engineering</h2>
+## Feature preprocessing and engineering
 <p>I will use the same steps of feature preprocessing and engineering from <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a> here, in order to have an apples to apples comparison of the 2 models.</p>
 <pre class="r"><code>tweets %&gt;% 
   mutate(target = as.factor(target),
@@ -105,14 +81,10 @@ recipe(target ~ ., data = tweets_train) %&gt;%
 tweets_prep &lt;- tweets_recipe %&gt;% 
   prep(training = tweets_train, 
        strings_as_factors = FALSE)</code></pre>
-</div>
-<div id="modelling" class="section level2">
-<h2>Modelling</h2>
-<div id="lasso-regression-using-glmnet" class="section level3">
-<h3>Lasso Regression using glmnet</h3>
+## Modelling
+### Lasso Regression using glmnet
 <p>Let’s build a basic logistic regression model with some default value of regularization penalty.</p>
-<div id="basic" class="section level4">
-<h4>Basic</h4>
+#### Basic
 <pre class="r"><code>lasso_spec &lt;- logistic_reg(penalty = 0.1, mixture = 1) %&gt;% 
   set_engine(&quot;glmnet&quot;) %&gt;% 
   set_mode(&quot;classification&quot;) 
@@ -144,9 +116,7 @@ lasso_fit %&gt;%
 ## 10 (Intercept)     6  -0.288  0.0951  5.21e- 2
 ## # … with 11,674 more rows</code></pre>
 <p>Above we see the familiar output of glmnet. Now, Let’s try and tune the regularization penalty and visualize the results.</p>
-</div>
-<div id="tuning-lasso-penalty" class="section level4">
-<h4>Tuning lasso penalty</h4>
+#### Tuning lasso penalty
 <p>Using 10-fold cross validation and a few different values of regularization penalty.</p>
 <pre class="r"><code>set.seed(1234)
 folds &lt;- vfold_cv(tweets_train, strata = target, v = 10, repeats = 3)
@@ -264,11 +234,7 @@ lasso_last_fit %&gt;%
        subtitle = &quot;&#39;num_hashtags&#39; feature gets to zero coefficient very soon in comparison&quot;)</code></pre>
 <p><img src="/post/2020-04-06-nlp-with-disaster-tweets-part-3-linear-models_files/figure-html/unnamed-chunk-16-1.png" width="672" /></p>
 <p>All feature coefficients tend to move towards zero as we increase the lambda penalty parameter, some more quickly than others.</p>
-</div>
-</div>
-</div>
-<div id="model-calibration" class="section level2">
-<h2>Model Calibration</h2>
+## Model Calibration
 <p>Another method to measure model performance is to see how well calibrated a model is on the validation dataset. Let’s compare our 2 models, lasso regression here and the best k-nearest neighbor model from <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a>, by plotting calibration plots for each of them.</p>
 <pre class="r"><code>readRDS(&quot;../data/nlp_with_disaster_tweets/knn/knn_last_fit.rds&quot;) %&gt;% 
   collect_predictions() %&gt;% 
@@ -312,14 +278,9 @@ lasso_last_fit %&gt;%
 The KNN model calibration plot shows that the curve is above the diagonal, i.e. the model is frequently under estimating the predicted probabilities.<br />
 However, the lasso regression seems to be well calibrated out of the box. That’s a sign of good stable algorithm and training procedure.<br />
 Note that all the predicted probabilities here are calculated on the cross validation set.</p>
-</div>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In the next part of this series, I will start building models with a different class of function space, like piece-wise constant functions and linear combination of piece-wise constant functions classes i.e. simple decision trees and gradient boosted trees respectively. As we see in this blog post that the class of linear functions do give better performing models and we learnt our problem space to be leaning towards flexible models in <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a>, I expect to see better results for different, more flexible modelling approaches.</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a></li>
@@ -327,4 +288,3 @@ Note that all the predicted probabilities here are calculated on the cross valid
 <li>Lasso Regression using <a href="https://juliasilge.com/blog/lasso-the-office/" target="_blank">Tidymodels by Julia Silge</a>.</li>
 <li>Introduction to Statistical Learning - <a href="https://www.amazon.com/Introduction-Statistical-Learning-Applications-Statistics/dp/1461471370" target="_blank">Book</a></li>
 </ul>
-</div>

--- a/posts/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us.qmd
+++ b/posts/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us.qmd
@@ -27,33 +27,12 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#analysis">Analysis</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#loading-processed-data-from-previous-part">Loading processed data from previous part</a></li>
-<li><a href="#feature-preprocessing-and-engineering">Feature preprocessing and engineering</a></li>
-<li><a href="#modelling">Modelling</a><ul>
-<li><a href="#decision-trees-using-rpart">Decision Trees using rpart</a></li>
-<li><a href="#gradient-boosted-trees-using-xgboost">Gradient Boosted Trees using xgboost</a></li>
-</ul></li>
-<li><a href="#model-calibration">Model Calibration</a></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 4 for Tree based Modelling, I will use the processed data generated in <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">Part 1</a> to train decision trees and gradient boosted tree based models in order to predict if a tweet is about a real disaster or not using the tidymodels framework. Following up from the previous <a href="/2020/04/nlp-with-disaster-tweets-part-3-linear-models/" target="_blank">Part 3</a> about Linear models, I will do a comparative study among all these modelling algorithms.</p>
-</div>
-<div id="analysis" class="section level1">
-<h1>Analysis</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Analysis
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(tidyverse)
 library(ggplot2)
@@ -64,9 +43,7 @@ library(silgelib)
 library(rpart.plot)
 
 theme_set(theme_plex())</code></pre>
-</div>
-<div id="loading-processed-data-from-previous-part" class="section level2">
-<h2>Loading processed data from previous part</h2>
+## Loading processed data from previous part
 <pre class="r"><code>tweets &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_proc.rds&quot;)
 tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_proc.rds&quot;)</code></pre>
 <pre class="r"><code>tweets %&gt;% 
@@ -75,9 +52,7 @@ tweets_final &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/tweets_test_pr
 <pre class="r"><code>tweets_final %&gt;% 
   dim</code></pre>
 <pre><code>## [1] 3263  829</code></pre>
-</div>
-<div id="feature-preprocessing-and-engineering" class="section level2">
-<h2>Feature preprocessing and engineering</h2>
+## Feature preprocessing and engineering
 <p>I will use the same steps of feature preprocessing and engineering from <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a> here, in order to have an apples to apples comparison of all the models.</p>
 <pre class="r"><code>tweets %&gt;% 
   mutate(target = as.factor(target),
@@ -107,14 +82,10 @@ recipe(target ~ ., data = tweets_train) %&gt;%
 tweets_prep &lt;- tweets_recipe %&gt;% 
   prep(training = tweets_train, 
        strings_as_factors = FALSE)</code></pre>
-</div>
-<div id="modelling" class="section level2">
-<h2>Modelling</h2>
-<div id="decision-trees-using-rpart" class="section level3">
-<h3>Decision Trees using rpart</h3>
+## Modelling
+### Decision Trees using rpart
 <p>Let’s build a basic decision tree model with default values.</p>
-<div id="basic" class="section level4">
-<h4>Basic</h4>
+#### Basic
 <pre class="r"><code>dtree_spec &lt;- decision_tree() %&gt;% 
   set_engine(&quot;rpart&quot;) %&gt;% 
   set_mode(&quot;classification&quot;) 
@@ -132,13 +103,9 @@ pull_workflow_fit(dtree_fit)$fit %&gt;%
   rpart.plot()</code></pre>
 <p><img src="/post/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us_files/figure-html/unnamed-chunk-7-1.png" width="672" /></p>
 <p>Above we see the familiar plot of rpart, showing PC009 to be the most important variable.</p>
-</div>
-</div>
-<div id="gradient-boosted-trees-using-xgboost" class="section level3">
-<h3>Gradient Boosted Trees using xgboost</h3>
+### Gradient Boosted Trees using xgboost
 <p>Let’s build a basic boosted tree model with default values.</p>
-<div id="basic-1" class="section level4">
-<h4>Basic</h4>
+#### Basic
 <pre class="r"><code>gbtree_spec &lt;- boost_tree() %&gt;% 
   set_engine(&quot;xgboost&quot;) %&gt;% 
   set_mode(&quot;classification&quot;) 
@@ -151,9 +118,7 @@ wf &lt;- workflow() %&gt;%
 
 saveRDS(gbtree_fit, &quot;../data/nlp_with_disaster_tweets/trees/gbtree_basic_fit.rds&quot;)</code></pre>
 <pre class="r"><code>gbtree_fit &lt;- readRDS(&quot;../data/nlp_with_disaster_tweets/trees/gbtree_basic_fit.rds&quot;)</code></pre>
-</div>
-<div id="tuning-boosted-tree-parameters" class="section level4">
-<h4>Tuning boosted tree parameters</h4>
+#### Tuning boosted tree parameters
 <p>Using 5-fold cross validation and a few different values of various parameters.</p>
 <pre class="r"><code>set.seed(1234)
 folds &lt;- vfold_cv(tweets_train, strata = target, v = 5, repeats = 1)
@@ -250,11 +215,7 @@ gbtree_last_fit %&gt;%
        subtitle = &quot;PC009 remains to be the most important feature&quot;)</code></pre>
 <p><img src="/post/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us_files/figure-html/unnamed-chunk-18-1.png" width="672" /></p>
 <p>Since most of our features are the dimensionally reduced different dimensions coming out of the glove embeddings, we can not interpret them. However, one thing to note here, for gradient boosted trees, none of our custom features turn out to be of any significant importance.</p>
-</div>
-</div>
-</div>
-<div id="model-calibration" class="section level2">
-<h2>Model Calibration</h2>
+## Model Calibration
 <p>Another method to measure model performance is to see how well calibrated a model is on the validation dataset. Let’s compare our 3 models, gradient boosted trees here, lasso regression in <a href="/2020/04/nlp-with-disaster-tweets-part-3-linear-models/" target="_blank">Part 3</a> and the best k-nearest neighbor model from <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a>, by plotting calibration plots for each of them.</p>
 <pre class="r"><code>readRDS(&quot;../data/nlp_with_disaster_tweets/knn/knn_last_fit.rds&quot;) %&gt;% 
   collect_predictions() %&gt;% 
@@ -317,18 +278,12 @@ gbtree_last_fit %&gt;%
 The KNN model calibration plot shows that the curve is above the diagonal, i.e. the model is frequently under estimating the predicted probabilities.<br />
 However, both lasso regression and gradient boosted tree models seem to be well calibrated out of the box. That’s a sign of good stable algorithm and training procedure.<br />
 Note that all the predicted probabilities here are calculated on the cross validation set.</p>
-</div>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In this part I built tree based models in order to understand how the problem space can be modelled with these approaches. We do see a small improvement in f1-score as compared to all our previous approaches. Note that, due to limited compute resources on my mac, I have kept the size of tuning grid to be small. In the next part of this series, I will move focus towards neural networks based models and see how “deep” we can go. Other NLP strategies like Named-entity recognition and others are also on my bucket list for this series.</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a></li>
 <li>Project Part 2 - <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">NLP with Disaster Tweets: Part 2 Nearest Neighbor Models</a></li>
 <li>Project Part 3 - <a href="/2020/04/nlp-with-disaster-tweets-part-3-linear-models/" target="_blank">NLP with Disaster Tweets: Part 3 Linear Models</a></li>
 </ul>
-</div>

--- a/posts/2020-05-14-from-tensorflow-to-pytorch.en-us.qmd
+++ b/posts/2020-05-14-from-tensorflow-to-pytorch.en-us.qmd
@@ -26,30 +26,8 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#modelling">Modelling</a><ul>
-<li><a href="#load-libraries">Load Libraries</a></li>
-<li><a href="#tensorflow">Tensorflow</a><ul>
-<li><a href="#prep-data">Prep Data</a></li>
-<li><a href="#network-architecture">Network Architecture</a></li>
-<li><a href="#fit-and-evaluate">Fit and evaluate</a></li>
-</ul></li>
-<li><a href="#pytorch">PyTorch</a><ul>
-<li><a href="#prep-data-1">Prep data</a></li>
-<li><a href="#network-architecture-1">Network Architecture</a></li>
-<li><a href="#fit-and-evaluate-1">Fit and evaluate</a></li>
-<li><a href="#simple-gradient-descent">Simple Gradient Descent</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>Recently I have been starting to learn and move towards PyTorch instead of Keras/Tensorflow, and I have to say I have been positively impressed by PyTorch’s neat API. However, I didn’t find a lot of articles around how to make that transition easy and I found myself going back and forth trying to lookup what are the corresponding layer functions or loss functions in PyTorch in comparison to tensorflow. This post is mostly to remind myself or anyone else who is making this transition by showing a basic deep learning toy example, which is written in both Tensorflow and PyTorch. It’ll be a quick small post and hopefully help anyone to quickly refer some basic Tensorflow vs. PyTorch functionality.</p>
 <p>Any neural network model training workflow follows the following basic steps -</p>
 <ol style="list-style-type: decimal">
@@ -62,11 +40,8 @@ freeze: true
 <li>Repeat step 2 above for another epoch.</li>
 </ol>
 <p>I will use the same above blueprint and build model in both these frameworks. Note that I am using Tensorflow’s <a href="https://www.tensorflow.org/tutorials/quickstart/beginner" target="_blank">quickstart tutorial</a> as the toy model and will build corresponding model in PyTorch.</p>
-</div>
-<div id="modelling" class="section level1">
-<h1>Modelling</h1>
-<div id="load-libraries" class="section level2">
-<h2>Load Libraries</h2>
+# Modelling
+## Load Libraries
 <pre class="r"><code>rm(list = ls())
 library(reticulate)
 
@@ -82,20 +57,15 @@ import torch.optim as optim
 import numpy as np
 
 torch.__version__</code></pre>
-</div>
-<div id="tensorflow" class="section level2">
-<h2>Tensorflow</h2>
-<div id="prep-data" class="section level3">
-<h3>Prep Data</h3>
+## Tensorflow
+### Prep Data
 <pre class="python"><code>mnist = tf.keras.datasets.mnist
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 x_train, x_test = x_train / 255.0, x_test / 255.0
 
 print(&#39;X_TRAIN: {0} Y_TRAIN: {1} \n X_TEST: {2} Y_TEST: {3}&#39;.format(x_train.shape, y_train.shape, x_test.shape, y_test.shape))</code></pre>
 <p>Using the classic MNIST dataset to predict the handwritten digit.</p>
-</div>
-<div id="network-architecture" class="section level3">
-<h3>Network Architecture</h3>
+### Network Architecture
 <pre class="python"><code>model = tf.keras.models.Sequential([
   tf.keras.layers.Flatten(input_shape=(28, 28)),
   tf.keras.layers.Dense(128, activation=&#39;relu&#39;),
@@ -110,9 +80,7 @@ model.compile(optimizer=&#39;adam&#39;,
               metrics=[&#39;accuracy&#39;])</code></pre>
 <p>In the above simple network, we first flatten the 2d image of the handwritten digits from 28x28 pixel values to single vector of 784 values. Next, we apply a fully connected dense layer with 128 hidden nodes and relu activation. Followed by a dropout layer with 20% dropout probability and then our final Dense layer that calculates the log-odds for each of the 10 digits.<br />
 Next we define our loss function, the categorical cross entropy function (with parameters that uses logits to calculate the loss value) and the Adam Optimizer that will help train the network more efficiently as compared to using a simple gradient descent optimizer.</p>
-</div>
-<div id="fit-and-evaluate" class="section level3">
-<h3>Fit and evaluate</h3>
+### Fit and evaluate
 <pre class="python"><code>model.fit(x_train, y_train, epochs=5)</code></pre>
 <p>We train our model for 5 epochs above and evaluate below.</p>
 <pre class="python"><code>model.evaluate(x_test,  y_test, verbose=2)
@@ -125,12 +93,8 @@ probability_model = tf.keras.Sequential([
 probability_model(x_test[:3]).numpy()</code></pre>
 <p>In order to calculate predicted probability for each digit (instead of log-odds), we run our model output through a simple softmax function and display the predicted probabilities for the first 3 samples in the test data.</p>
 <p>Now moving on to PyTorch!</p>
-</div>
-</div>
-<div id="pytorch" class="section level2">
-<h2>PyTorch</h2>
-<div id="prep-data-1" class="section level3">
-<h3>Prep data</h3>
+## PyTorch
+### Prep data
 <pre class="python"><code>x_train_torch = torch.from_numpy(x_train)
 y_train_torch = torch.from_numpy(y_train)
 
@@ -142,9 +106,7 @@ x_test_torch = x_test_torch.float()
 y_train_torch = y_train_torch.long()
 y_test_torch = y_test_torch.long()</code></pre>
 <p>We are using the same MNIST dataset we used for building our Tensorflow example but converting it to PyTorch tensors and making sure they have the correct datatypes.</p>
-</div>
-<div id="network-architecture-1" class="section level3">
-<h3>Network Architecture</h3>
+### Network Architecture
 <pre class="python"><code>class Net(nn.Module):
     def __init__(self):
         super(Net, self).__init__()
@@ -165,9 +127,7 @@ loss_fn = nn.CrossEntropyLoss()
 optimizer = optim.Adam(torch_model.parameters(), lr = 0.001)</code></pre>
 <p>With PyTorch, we get to build the network architecture in a more object oriented fashion where we define each layer in the class constructor and a forward function that defines how the input data will pass forward through the network. Note that, we do not need to have a separate “Flatten” layer in PyTorch like we did in Tensorflow, we can just restructure the tensor using the “view” function to achieve the same effect.<br />
 We define the same loss function (CrossEntropyLoss), note however PyTorch’s CrossEntropyLoss function applies Softmax internally. We also initialize our Adam optimizer object.</p>
-</div>
-<div id="fit-and-evaluate-1" class="section level3">
-<h3>Fit and evaluate</h3>
+### Fit and evaluate
 <pre class="python"><code>torch_model.train()
 for epoch in range(30):
     y_pred = torch_model(x_train_torch)
@@ -189,9 +149,7 @@ preds = torch_model(x_test_torch).detach().numpy()
 preds = np.argmax(preds, axis=1)
 np.mean(y_test_torch.numpy() == preds)</code></pre>
 <p>I also wanted to run this network through a simple gradient descent instead of a pre-built optimizer just out of curiosity to see how well it performs.</p>
-</div>
-<div id="simple-gradient-descent" class="section level3">
-<h3>Simple Gradient Descent</h3>
+### Simple Gradient Descent
 <pre class="python"><code>torch_model = Net()
 learning_rate = 1e-4
 
@@ -217,17 +175,10 @@ preds = torch_model(x_test_torch).detach().numpy()
 preds = np.argmax(preds, axis=1)
 np.mean(y_test_torch.numpy() == preds)</code></pre>
 <p>So intead of using the adam optimizer, we manually use the learning rate and the computed gradient for each parameter and update the value for each param during an epoch. As we see the model doesn’t perform quite as well, but nevertheless we now know how we can use PyTorch’s cool API to fully control every aspect of training the neural network.</p>
-</div>
-</div>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In summary, I think both Tensorflow and PyTorch provide solid frameworks for training neural networks. If you prefer more intuitive, easy-to-use API Tensorflow should be the way to go and if you like a neat object-oriented, more fine-grained control API then PyTorch serves that purpose well.</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Tensorflow’s <a href="https://www.tensorflow.org/tutorials/quickstart/beginner" target="_blank">quickstart tutorial</a></li>
 <li>PyTorch <a href="https://pytorch.org/docs/stable/index.html" target="_blank">docs</a></li>
 </ul>
-</div>

--- a/posts/2020-08-25-nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us.qmd
+++ b/posts/2020-08-25-nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us.qmd
@@ -27,30 +27,13 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#vocabulary-vectorizer-and-more">Vocabulary, Vectorizer and More</a><ul>
-<li><a href="#vocabulary">Vocabulary</a></li>
-<li><a href="#vectorizer">Vectorizer</a></li>
-<li><a href="#dataset">Dataset</a></li>
-<li><a href="#data-module">Data Module</a></li>
-</ul></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 5 for Deep Learning data preparation, I will use the raw data with the splits generated in <a href="/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/" target="_blank">Part 2</a> to create a single class of Data Module that holds all the preprocessing, vectorization and PyTorch DataLoaders implementation as preparation for use in future deep learning models using PyTorch. Following up from the previous <a href="/2020/04/nlp-with-disaster-tweets-part-4-tree-based-models.en-us/" target="_blank">Part 4</a> about tree-based models, I will move to creating Neural Networks to classify these tweets in upcoming posts.</p>
-</div>
-<div id="vocabulary-vectorizer-and-more" class="section level1">
-<h1>Vocabulary, Vectorizer and More</h1>
+# Vocabulary, Vectorizer and More
 <p>I will be using the <a href="https://github.com/PyTorchLightning/pytorch-lightning#pytorch-lightning-masterclass" target="_blank">pytorch-lightning</a> framework to build a consistent DataModule class which will hold the logic of generating train, val and test datasets and creating corresponding data loaders that manage in-built batching and shuffling functionality. First things first, let’s start with the Vocabulary class.</p>
-<div id="vocabulary" class="section level2">
-<h2>Vocabulary</h2>
+## Vocabulary
 <p>The vocabulary class will be responsible for converting the individual tokens (i.e. words) in our tweets to numerical indices. It is basically a simple dictionary with some sugar.</p>
 <pre class="python"><code>class Vocabulary:
     def __init__(self):
@@ -100,9 +83,7 @@ In this part 5 for Deep Learning data preparation, I will use the raw data with 
             return self._token_to_idx.get(token, self.unk_index)
         else:
             return self._token_to_idx[token]</code></pre>
-</div>
-<div id="vectorizer" class="section level2">
-<h2>Vectorizer</h2>
+## Vectorizer
 <p>Now that we have our vocabulary in place, we will need a vectorizer class that will, given a dataframe, create the exact vocabulary for the given dataset and also provide functionality to transform a single tweet text into a numerical vector representation.</p>
 <pre class="python"><code>class TweetsVectorizer:
     def __init__(self, text_vocab):
@@ -207,9 +188,7 @@ In this part 5 for Deep Learning data preparation, I will use the raw data with 
 <p>[2, 4, 5, 6, 7, 8, 3, 0, 0, 0, 0, 0, 0, ….. 0]</p>
 </blockquote>
 <p>with 0s appended in the end uptil the length of the longest tweet.</p>
-</div>
-<div id="dataset" class="section level2">
-<h2>Dataset</h2>
+## Dataset
 <p>Now we are ready to create the Dataset object for our data which is the abstraction provided by PyTorch for easy data transport and loading.</p>
 <pre class="python"><code>from torch.utils.data import Dataset
 
@@ -242,9 +221,7 @@ class TweetsDataset(Dataset):
 <li>It runs the vectorization and returns all the relevant fields.</li>
 </ul>
 <p>We will create 3 instances of the TweetsDataset class, one for each train, val and test splits. These will be used in the Data Module accordingly to load data via Data Loaders.</p>
-</div>
-<div id="data-module" class="section level2">
-<h2>Data Module</h2>
+## Data Module
 <p>PyTorch Lightning provides a fantastic <a href="https://pytorch-lightning.readthedocs.io/en/latest/datamodules.html?highlight=datamodule" target="_blank">LightningDataModule</a> class that helps create a shareable, reusable object that encapsulates all the steps needed to process data.</p>
 <pre class="python"><code>import pytorch_lightning as pl
 
@@ -307,14 +284,9 @@ class DisasterTweetsDataModule(pl.LightningDataModule):
 <li>Finally, the <code>train_dataloader</code> function wraps the train dataset object in a DataLoader object provided by PyTorch. This will generate batches of data and is also configured to shuffle the data and drop records (if any) if they do not form a complete batch.</li>
 <li>Similarly, I have also added <code>val_dataloader</code> and <code>test_dataloader</code> methods (not shown here for brevity) that generate DataLoader objects for val and test Datasets respectively. PS, both of those will need to have shuffling and drop_last turned off.</li>
 </ul>
-</div>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In this part of the series, we have done our ground work for data preparation which we can use to jumpstart our Deep Learning modelling process. The full code for this class can be viewed on my github <a href="https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/disaster_tweets_data_module.py" target="_blank">here</a>. In the next part, I will start building a simple multi-layer perceptron using PyTorch Lightning and the DataModule class that we discussed in this part. See you there!</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a></li>
@@ -326,4 +298,3 @@ class DisasterTweetsDataModule(pl.LightningDataModule):
 <li>Natural Language Processing with PyTorch - <a href="https://learning.oreilly.com/library/view/natural-language-processing/9781491978221/" target="_blank">ebook</a></li>
 <li>Full DisasterTweetsDataModule implementation - <a href="https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/disaster_tweets_data_module.py" target="_blank">github</a></li>
 </ul>
-</div>

--- a/posts/2020-09-02-nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us.qmd
+++ b/posts/2020-09-02-nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us.qmd
@@ -28,33 +28,14 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#classifier-class">Classifier Class</a><ul>
-<li><a href="#network-architecture-and-loss-function">Network Architecture and Loss Function</a></li>
-<li><a href="#optimizer">Optimizer</a></li>
-<li><a href="#forward-method">Forward Method</a></li>
-<li><a href="#training-step-val-step-test-step">Training Step / Val Step / Test Step</a></li>
-</ul></li>
-<li><a href="#the-training-routine">The Training Routine</a></li>
-<li><a href="#inference-and-results">Inference and Results</a></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 6 for building Multi Layer Perceptron, I will use the data module generated in <a href="/2020/08/nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us/" target="_blank">Part 5</a> to create a Multi Layer Perceptron model to predict if the tweet is about a real disaster. Following up from the previous <a href="/2020/04/nlp-with-disaster-tweets-part-4-tree-based-models.en-us/" target="_blank">Part 4</a> about tree-based models, I will generate the prediction output of this model on the validation set and compare results.</p>
-</div>
-<div id="classifier-class" class="section level1">
-<h1>Classifier Class</h1>
+# Classifier Class
 <div class="figure">
 <img src="https://lh3.googleusercontent.com/UjkRMf-8bTQjE3bFfik8N4no1aH7m7J0PgZEmjuUh4uSLXpLsvSRy_lgOHsRkbPnLQ1CYLPjX6WwEZQpeAuikZi_hfSqKoYw6afUzPYuteoVf9wGmeVXJE7snQMi5oiG1sAuvNwYRJbyy7CuqdOhQSplrfMjJBwNT8xPanGEHwqdaHOiBuVyWr5yYNkJpwcbNbvlI542gq0ZBE5rYe1o4kiTmTwTpi8HaEJ8qjEbXamTDQQtEYiFcmsqBcCOl2uBLhbCtSAXJvz6WV2fN04x6QoGUaVz4ohQDYSYnkdSVWY4FcCAWMl7IrQJnhkZNTF33DWr9MXEtVEFVEVp6qOqMb0qwwPGwP08HMOrK2wPLVjhXRd_flitm3a3qhqMDp0kyjycW5ZAdELWoBycSpdWHIAmev2AP3iDOkmfYUsJTTjK2nHazbEw1pIXKgnkdV4-SS-0xpW04iTtXaTPLaG9IVYOH92cR1LitfmZTJVnF4MxzDveqGQQWcTmZSfuvuNzAImvagx6KTTaQ_peIzsRzeo_LcDZHC2xrDLXoinEknvrNt4VhahVMD5C7Mq4fpVePqROTvfiB1jNbIXmovZPetmjESLt0egU-vPYq4gZbJvTmRrSOV2v4SH1kCKZQOnIkD72JnA-BDcSNGyuB_kmFUqSSEx9gcSyZPTa1VYdBy9rSauEPnWl08BY5cnreQ=w600-h331-no" alt="" />
 <p class="caption">Mutli-Layer Perceptron Pictorial representation from <a href="https://www.tutorialspoint.com/tensorflow/tensorflow_multi_layer_perceptron_learning.htm" class="uri">https://www.tutorialspoint.com/tensorflow/tensorflow_multi_layer_perceptron_learning.htm</a></p>
-</div>
 <p>Above pictorial representation shows a simple multi-layer perceptron with 2 hidden layers. We will essentially build the same for our usecase with a few more layers and additional bells and whistles related to network regularization.</p>
 <p>I will be using the <a href="https://github.com/PyTorchLightning/pytorch-lightning" target="_blank">pytorch-lightning</a> framework to build a classifier class.<br />
 In a deep learning training pipeline we need to configure the following 5 essential components -</p>
@@ -67,8 +48,7 @@ In a deep learning training pipeline we need to configure the following 5 essent
 <li><strong>Training Step / Val Step / Test Step</strong> - We configure specific to each phase (train/val/test) how exactly we will compute and report the loss.</li>
 </ul>
 <p>That’s it! Rest everything related to epoch loop, checkpointing, logging, book-keeping are handled by PyTorch Lightning so we do not need to implement that specifically (as we would have if we were to use vanilla PyTorch. example <a href="/2020/05/from-tensorflow-to-pytorch.en-us" target="_blank">here</a>). In the rest of the post I will mainly discuss the above 5 components specific to building a Multi Layer Perceptron for our Disaster Tweets usecase.</p>
-<div id="network-architecture-and-loss-function" class="section level2">
-<h2>Network Architecture and Loss Function</h2>
+## Network Architecture and Loss Function
 <p>A multi layer perceptron is a simple neural network where neurons in each layer are fully connected to all the neurons in the next layer. Weights are applied to each input feature by a linear transform along with a bias and non-linearity is introduced via the activation function. Let’s see how our network architecture and loss function look.</p>
 <pre class="python"><code>import pytorch_lightning as pl
 
@@ -119,18 +99,14 @@ class DisasterTweetsClassifierMLP(pl.LightningModule):
 </li>
 <li>Loss Function - We are using the <strong>Cross Entropy Loss</strong> function here. My favorite explanation for this loss is <a href="https://gombru.github.io/2018/05/23/cross_entropy_loss/" target="_blank">this</a> post that does a beautiful job of explaining how exactly it is computed and how its gradient is calculated. The reason for passing ‘reduction=none’ in the loss function will become clear in the section below about training/val step.</li>
 </ul>
-</div>
-<div id="optimizer" class="section level2">
-<h2>Optimizer</h2>
+## Optimizer
 <pre class="python"><code>class DisasterTweetsClassifierMLP(pl.LightningModule):
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(),
                                 lr=self.hparams.learning_rate,
                                 weight_decay=self.hparams.weight_decay)</code></pre>
 <p>We are using the <strong>Adam</strong> optimizer for optimizer our network parameters which is a good default optimizer as it combines advantages of 2 other well known optimizers AdaGrad and RMSProp. <a href="https://machinelearningmastery.com/adam-optimization-algorithm-for-deep-learning/" target="_blank">Here</a> is a gentle introduction on Adam optimizer. We pass in all our network parameters, the provided learning rate and weight decay hyper parameters to <code>torch.optim.Adam</code>.</p>
-</div>
-<div id="forward-method" class="section level2">
-<h2>Forward Method</h2>
+## Forward Method
 <pre class="python"><code>class DisasterTweetsClassifierMLP(pl.LightningModule):
   def forward(self, batch):
         x_embedded = self.emb(batch).view(batch.size(0), -1)
@@ -139,9 +115,7 @@ class DisasterTweetsClassifierMLP(pl.LightningModule):
         return output</code></pre>
 <p>In the forward pass through the network, we first generate the embeddings for our batch and also flatten it. For example, if we had batch size as 8 and each of the 8 samples were of normalized length 70, then the <code>self.emb</code> embedding layer will transform it to a tensor <code>8 x 70 x 25</code> (if we were to use 25 dimensional glove embeddings). i.e. it’ll extract the 25-dimensional embedding for each of 70 words in our 8 samples. Then the <code>view(batch.size(0), -1)</code> will flatten it such that the tensor will transform from <code>8 x 70 x 25</code> to <code>8 x 1750</code> (i.e. it’ll append the embedding vectors of all 70 words in the sample for all 8 samples).<br />
 This flattened vector then gets passed through our <code>fc</code> fully connected layer and generates the output which gets returned.</p>
-</div>
-<div id="training-step-val-step-test-step" class="section level2">
-<h2>Training Step / Val Step / Test Step</h2>
+## Training Step / Val Step / Test Step
 <pre class="python"><code>class DisasterTweetsClassifierMLP(pl.LightningModule):
   def training_step(self, batch, batch_idx):
         y_pred = self(batch[&#39;x_data&#39;]) #internally calls the forward method
@@ -163,9 +137,7 @@ This flattened vector then gets passed through our <code>fc</code> fully connect
 <p>We have split the validation step in 2 methods. The <code>validation_step</code> and the <code>validation_epoch_end</code>. Since we want to summarize the loss for the entire validation dataset and not just for each individual validation batch, we only return the individual losses of each sample in the batch from our validation_step method (similar to how we computed in training step) and do the aggregation in the <code>validation_epoch_end</code> method, which as the name suggests runs after the validation epoch is over. Here, we see the reason for passing <code>reduction=none</code> in our loss function instantiation. Since, we don’t allow the loss function to do reduction, and handle it manually ourselves, we can use the same function for both train and validation steps. As we noted earlier, training loss gets computed over each batch and gets backpropogated, however validation loss is computed over the entire validation dataset and reported. We also compute accuracy on our validation set for reporting purposes.</p>
 <p>The test step is exactly identical to the validation step (Mutatis mutandis). i.e. Test dataset used instead of validation dataset.</p>
 </div>
-</div>
-<div id="the-training-routine" class="section level1">
-<h1>The Training Routine</h1>
+# The Training Routine
 <p>With all the above work, our network is all set and ready to train. Let’s discuss the training routine which remains mostly same across different networks. It majorly has class object creation, logger configuration and running the <code>fit</code> method on our trainer.</p>
 <pre class="python"><code>if __name__ == &#39;__main__&#39;:
   pl.seed_everything(42)
@@ -200,13 +172,10 @@ This flattened vector then gets passed through our <code>fc</code> fully connect
 <li>We also configure the TensorBoard Logger that will help visualize and monitor the training routine.</li>
 <li>Finally, we call the <code>fit</code> method of the trainer with the Model object and the Lightning Data Module object.</li>
 </ul>
-</div>
-<div id="inference-and-results" class="section level1">
-<h1>Inference and Results</h1>
+# Inference and Results
 <div class="figure">
 <img src="https://lh3.googleusercontent.com/pw/ACtC-3cxsz2O5JYhPo9QiqUx6DfcWzA6MuP6mOSS9eVw-lSuK0NhaagIN1NxnZQwEy-GDwldRy-UqDBsZV1nDKtbzbHRwvaP1gXhuFomirKsCaED29flV6r7tP8tH5dAmrpa5oF0EuIQZJXCUvMQzG5adFtGKQ=w452-h1044-no?authuser=0" alt="" />
 <p class="caption">Training Routine Plots in Tensorboard</p>
-</div>
 <p>The above plots show the training routine visualizations in Tensorboard. We see the validation loss continuously decreases until around epoch=13 where it starts saturating and our early stopping callback gets triggered and stops the training.</p>
 <pre class="python"><code>def predict_target(text, classifier, vectorizer, max_seq_length):
     text_vector, _ = vectorizer.vectorize(text, max_seq_length)
@@ -217,12 +186,9 @@ This flattened vector then gets passed through our <code>fc</code> fully connect
     return {&#39;pred&#39;: target.item(), &#39;probability&#39;: probability.item()}</code></pre>
 <p>We can use the above method to run the trained model on new incoming text and generate predictions. When we run prediction on our validation dataset we get an accuracy score of <code>0.7835232252410167</code> and F1-score of <code>0.7507568113017156</code>. F1-score for the best tuned Gradient Boosted Tree model that we got in <a href="/2020/04/nlp-with-disaster-tweets-part-4-tree-based-models.en-us/#gradient-boosted-trees-using-xgboost" target="_blank">Part 4</a> was <code>0.8107538</code>, which is much higher than our multi-layer perceptron. However, note that this is just the default performance of this Network Architecture on our validation set with single constant values for our different hyperparameters like batch size, learning rate, hidden layers etc. We can do a full hyperparameter sweep and tune this network to get an optimal performance number (coming up in a future post).</p>
 </div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In this part of the series, we built a multi-layer perceptron neural network architecture to predict if a tweet is about a real disaster using the PyTorch Lightning framework. We built this on top of the Lightning Data Module that we discussed in the previous post of this series. We can see that we get a good solid baseline performance from this network and can hopefully with further hyperparameter tuning improve it. The full code for this post can be viewed on my github <a href="https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/3.2-am-pl-mlp-glove-disaster-tweets.py" target="_blank">here</a>. In the next part, I will build a Recurrent Neural Network for this task using our same underlying data module. Hope to see you there.</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a></li>
@@ -235,4 +201,3 @@ This flattened vector then gets passed through our <code>fc</code> fully connect
 <li>Natural Language Processing with PyTorch - <a href="https://learning.oreilly.com/library/view/natural-language-processing/9781491978221/" target="_blank">ebook</a></li>
 <li>Full DisasterTweetsClassifierMLP implementation - <a href="https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/3.2-am-pl-mlp-glove-disaster-tweets.py" target="_blank">github</a></li>
 </ul>
-</div>

--- a/posts/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.qmd
+++ b/posts/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.qmd
@@ -28,30 +28,11 @@ freeze: true
 
 
 
-<div id="TOC">
-<ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#classifier">Classifier</a><ul>
-<li><a href="#network-architecture">Network Architecture</a><ul>
-<li><a href="#vanilla-rnns-for-sentence-classification">Vanilla RNNs for Sentence Classification</a></li>
-<li><a href="#gated-recurrent-units-gru-for-sentence-classification">Gated Recurrent Units (GRU) for Sentence Classification</a></li>
-</ul></li>
-<li><a href="#forward-method">Forward Method</a></li>
-</ul></li>
-<li><a href="#the-training-routine">The Training Routine</a></li>
-<li><a href="#results">Results</a></li>
-<li><a href="#summary">Summary</a></li>
-<li><a href="#references">References</a></li>
-</ul>
-</div>
 
-<div id="introduction" class="section level1">
-<h1>Introduction</h1>
+# Introduction
 <p>In this <a href="https://www.kaggle.com/c/nlp-getting-started" target="_blank">NLP getting started challenge</a> on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.<br />
 In this part 7 for building RNNs, I will use the data module generated in <a href="/2020/08/nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us/" target="_blank">Part 5</a> to create a RNN models to predict if the tweet is about a real disaster. Following up from the previous <a href="/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/" target="_blank">Part 6</a> about multi-layer perceptron model, I will generate the prediction output of this model on the validation set and compare results.</p>
-</div>
-<div id="classifier" class="section level1">
-<h1>Classifier</h1>
+# Classifier
 <p>I will be using the <a href="https://github.com/PyTorchLightning/pytorch-lightning" target="_blank">pytorch-lightning</a> framework to build a classifier class.<br />
 Let’s follow the same overall flow of modelling that we had in <a href="/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/" target="_blank">Part 6</a>. The training pipeline will have the following components -</p>
 <ul>
@@ -63,15 +44,12 @@ Let’s follow the same overall flow of modelling that we had in <a href="/2020/
 <li><strong>Training Step / Val Step / Test Step</strong></li>
 </ul>
 <p>Note that the Loss Function, the Optimizer and the training/val/test steps remains the same as our Multilayer Perceptron from <a href="/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/" target="_blank">Part 6</a>, so I will only discuss the remaining 2 components in this part.</p>
-<div id="network-architecture" class="section level2">
-<h2>Network Architecture</h2>
+## Network Architecture
 <p>The essential idea of a Recurrent Neural Network is to process the words (tokens) in an input sentence sequentially, by applying the same weights W repeatedly to the output of previous word. The output at each processed word is called the hidden state. It looks like the following pictorial representation.</p>
 <div class="figure">
 <img src="https://lh3.googleusercontent.com/pw/ACtC-3eaiycpvplnp4dqTjPVk3La1j605Lx0oqD3kbX_zgljdIqRAVKi_lvs1XQq9ET_PHfHEVpwrNMcx0YbWYy3KTTKkZnnECkoYtSud6OqrOQVjk-hLOxHOH3liJvkyiLhxLfjn0jCU6sVHRCEBGViLON5ew=w1423-h670-no?authuser=1" alt="" />
 <p class="caption">Recurrent Neural Network Pictorial representation from <a href="https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf" class="uri">https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf</a></p>
-</div>
-<div id="vanilla-rnns-for-sentence-classification" class="section level3">
-<h3>Vanilla RNNs for Sentence Classification</h3>
+### Vanilla RNNs for Sentence Classification
 <p>In our usecase, we will use the above vanilla RNN to create a “Sentence Encoding” i.e. a vector of values that represent the given sentence and then pass that vector through another linear layer to make our final binary prediction of whether the given tweets is about a real disaster or not.</p>
 <p>The network architecture looks as follows.</p>
 <pre class="python"><code>import pytorch_lightning as pl
@@ -112,9 +90,7 @@ class DisasterTweetsClassifierRNN(pl.LightningModule):
 <li>We also pass the <code>bidirectional</code> flag to the RNN object. Like we discussed earlier, RNN processes input sentence sequentially, we can process the sentence from beginning to end or end to beginning. Usually, processing from both the directions and using the concatenated vector of both directions leads to higher predictive power.</li>
 <li>Finally we have 2 linear layers which transform the RNN output into our 2 layer output which can be used to calculate cross entropy loss.</li>
 </ul>
-</div>
-<div id="gated-recurrent-units-gru-for-sentence-classification" class="section level3">
-<h3>Gated Recurrent Units (GRU) for Sentence Classification</h3>
+### Gated Recurrent Units (GRU) for Sentence Classification
 <p>Vanilla RNNs suffer from the problem of Vanishing Gradients. In simple words, the basic RNNs discussed above are more impacted by near word effects instead of words which are far away. So, for sentences with longer length, at each RNN step, the model is only able to carry information from the previous few words and not from the words which are farther away but may have more relevance to the word in current step.<br />
 The issue mainly arises because we completely modify hidden state and weights at each step based on the currently incoming word and the hidden state vector becomes an information bottleneck. GRUs try to fix this problem by controlling how much of the previous hidden vector is forgotten and how much of it is kept/updated. Another popular variant to fix this problem is the LSTM (Long Short Term Memory) network which tries to keep a separate vector (cell state) as “memory” to hold information over long sequences. However, I am using GRU in my work in favour of limited compute power.</p>
 <p>This lecture by Abigail See at Stanford is the best resource IMO to understand the issues with Vanilla RNNs and how GRUs and LSTMs work to try and resolve them.</p>
@@ -136,15 +112,11 @@ class DisasterTweetsClassifierGRU(DisasterTweetsClassifierRNN):
 <li>Note that this class has the vanilla RNN class as a parent so it borrows almost all the implementation from there.</li>
 <li>The only difference in this GRU network is the usage of <code>torch.nn.GRU</code> instead of <code>torch.nn.RNN</code> in order to process the input sentences.</li>
 </ul>
-</div>
-</div>
-<div id="forward-method" class="section level2">
-<h2>Forward Method</h2>
+## Forward Method
 <p>The simplest and most basic way to create a sentence encoding using the above RNN is by just using the final hidden state of the sentence as the Sentence Encoding. Pictorially it looks like this.</p>
 <div class="figure">
 <img src="https://lh3.googleusercontent.com/pw/ACtC-3fPQJK7h2FE2nDDMaJDF7_4kObyfuQVgJHeF_nDF4Zav0VOHN7klITJLoZ6NujDfDROUwd6dA9dbdWMdwX2rQ_KRBiOHdDj_53xm9B1b0J7wK5SRpJj1FCpRqPsBF757G0EtHWX67jt9ijNKHVyQBbURg=w1494-h937-no?authuser=1" alt="" />
 <p class="caption">Recurrent Neural Network used for Sentence Classification Basic - Pictorial representation from <a href="https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf" class="uri">https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf</a></p>
-</div>
 <p>A usually better way is to do an element wise aggregation (max or mean) of all hidden states as theoretically it will contain information from all parts of the sentence while contributing to sentence encoding.</p>
 <div class="figure">
 <img src="https://lh3.googleusercontent.com/pw/ACtC-3dQIECTYZtxUJcxjj_ddSvc1Xj6fkDoSH_CPkjuGY-jpHh7Eicz0GHDFi58naBpwkOf_HG3PrMG0CvNbDt3Fieb76Xo3AqpmYeraKBq2Mspf3LwODe_8II2pgpHUbzzY0GAJM79M4evMd8Dy4CRKsjRcA=w1464-h939-no?authuser=1" alt="" />
@@ -175,12 +147,9 @@ class DisasterTweetsClassifierGRU(DisasterTweetsClassifierRNN):
 This final vector then gets passed through our <code>fc</code> fully connected layers and generates the output which gets returned.</p>
 </div>
 </div>
-<div id="the-training-routine" class="section level1">
-<h1>The Training Routine</h1>
+# The Training Routine
 <p>The training routine for these networks remains almost exactly the same as the one in <a href="/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/" target="_blank">Part 6</a>. Instead of instantiating an object of class <code>DisasterTweetsClassifierMLP</code>, we create objects of class <code>DisasterTweetsClassifierRNN</code> or <code>DisasterTweetsClassifierGRU</code>.</p>
-</div>
-<div id="results" class="section level1">
-<h1>Results</h1>
+# Results
 <table style="width:100%;">
 <colgroup>
 <col width="15%" />
@@ -274,13 +243,9 @@ This final vector then gets passed through our <code>fc</code> fully connected l
 <li>Aggregating hidden layers is better than just using the last hidden layer as the sentence encoding.</li>
 <li>Bidirectional GRU with Mean aggregation of hidden layers gives the best result of <code>0.7392739273927393</code> F1 Score. This F1 score is lower in comparison to the multilayer perceptron that we built in <a href="/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/" target="_blank">Part 6</a> and also much lower than the XGBoost tree we built in Part 4.</li>
 </ul>
-</div>
-<div id="summary" class="section level1">
-<h1>Summary</h1>
+# Summary
 <p>In this part of the series, we built a few Recurrent Neural Networks to predict if a tweet is about a real disaster using the PyTorch Lightning framework. We built this on top of the Lightning Data Module that we discussed in the previous post of this series. We can see that we get a good performance from this network and can hopefully with further hyperparameter tuning improve it. The full code for this post can be viewed on my github <a href="https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/3.3-am-pl-rnn-glove-disaster-tweets.py" target="_blank">here</a>. In the next part, I will use the Transformer Architecture based pre-trained models like BERT to generate predictions for our usecase.</p>
-</div>
-<div id="references" class="section level1">
-<h1>References</h1>
+# References
 <ul>
 <li>Project Summary Page - <a href="/2020/02/nlp-with-disaster-tweets/" target="_blank">NLP with disaster tweets: Summary</a></li>
 <li>Project Part 1 - <a href="/2020/02/nlp-with-disaster-tweets-part-1/" target="_blank">NLP with Disaster Tweets: Part 1 Data Preparation</a></li>
@@ -295,4 +260,3 @@ This final vector then gets passed through our <code>fc</code> fully connected l
 <li>Full DisasterTweetsClassifierRNN implementation - <a href="https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/3.3-am-pl-rnn-glove-disaster-tweets.py" target="_blank">github</a></li>
 <li>Stanford CS224N NLP with Deep Learning - <a href="https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf" target="_blank">Lecture Notes</a></li>
 </ul>
-</div>

--- a/tools/fix_headings.py
+++ b/tools/fix_headings.py
@@ -1,0 +1,33 @@
+import sys, re, os
+
+for path in sys.argv[1:]:
+    with open(path) as f:
+        lines = f.read().splitlines()
+
+    stack = []
+    out_lines = []
+    skip_toc = False
+    for line in lines:
+        stripped = line.strip()
+        if skip_toc:
+            if stripped == '</div>':
+                skip_toc = False
+            continue
+        if stripped == '<div id="TOC">':
+            skip_toc = True
+            continue
+        if re.match(r'<div id=".*" class="section level[0-9]">', stripped):
+            stack.append('section')
+            continue
+        m = re.match(r'<h([1-6])>(.*)</h\1>', stripped)
+        if m:
+            level = int(m.group(1))
+            text = m.group(2)
+            out_lines.append('#'*level + ' ' + text)
+            continue
+        if stripped == '</div>' and stack:
+            stack.pop()
+            continue
+        out_lines.append(line)
+    with open(path, 'w') as f:
+        f.write('\n'.join(out_lines) + '\n')


### PR DESCRIPTION
## Summary
- convert all converted posts to use Markdown headings instead of HTML h1/h2 tags
- drop the manual table of contents HTML
- add `tools/fix_headings.py` for converting posts

## Testing
- `apt-get update -y` *(passed)*
- `curl -L -o quarto.deb https://quarto.org/download/latest/quarto-linux-amd64.deb` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6849d043f370832aae85b8cb0cc1be15