### PR TITLE
Fix Markdown heading spacing

### DIFF
--- a/posts/2017-09-28-india-transportation-accidents-exploration-project.qmd
+++ b/posts/2017-09-28-india-transportation-accidents-exploration-project.qmd
@@ -26,6 +26,7 @@ output-file: india-transportation-accidents-exploration-project.html
 
 # Project Summary
 With this project I will try to visualize and understand the traffic accident data for India as publicly accessible [here](https://data.gov.in/).
+
 # Project Goals
 
 - Visualize traffic information and find trends

--- a/posts/2018-02-15-the-winter-olympics-makeovermonday-2018-week7.qmd
+++ b/posts/2018-02-15-the-winter-olympics-makeovermonday-2018-week7.qmd
@@ -29,7 +29,9 @@ output-file: the-winter-olympics-makeovermonday-2018-week7.html
 # Introduction
 Goal of this Visualization task is to create an alternative visualization to the [Tableau’s visualization for Winter Olympics data for different countries](https://public.tableau.com/views/TheWinterOlympics/TheWinterOlympics?:embed=y&:showVizHome=no)
 In this blog post, I’m trying to generate a World Choropleth Map showing the total counts of medals for each country.
+
 # Analysis
+
 ## Cleaning up workspace and loading required libraries
 ```r
 rm(list = ls())
@@ -44,6 +46,7 @@ library(rgeos)
 library(rgdal)
 library(stringr)
 ```
+
 ## Obtaining Data
 Reading and viewing the dataset
 ```r
@@ -119,6 +122,7 @@ olympics %>%
 ##  Max.   :42.00
 ##  NA's   :692
 ```
+
 ## Scrubbing data
 As per the dataset requirement, East and West Germany are to be grouped with Germany and Soviet Union and the 1992 Unified Team needs to be combined with Russia
 ```r
@@ -332,6 +336,7 @@ TotalMedalsPerCountry %>%
 ## # … with 29 more rows
 ```
 Germany obtained the most number of medals (377) closely followed by Russia with (341)
+
 ## Exploring Data
 Lets plot the above data on a map using leaflet.
 Loading shape file data set from [World Borders Dataset](http://thematicmapping.org/downloads/world_borders.php).

--- a/posts/2018-02-18-where-does-your-medicine-come-from-makeovermonday-2018-week-8.qmd
+++ b/posts/2018-02-18-where-does-your-medicine-come-from-makeovermonday-2018-week-8.qmd
@@ -29,7 +29,9 @@ output-file: where-does-your-medicine-come-from-makeovermonday-2018-week-8.html
 # Introduction
 Goal of this Visualization task is to create a visualization for the [Drug and Medicine Exports data for different countries.](https://www.trademap.org/Country_SelProduct_TS.aspx?nvpm=1|||||3004|||4|1|1|2|2|1|2|1|1)
 In this blog post, I’m trying to find the leading countries in Export across these 5 years.
+
 # Analysis
+
 ## Cleaning up workspace and loading required libraries
 ```r
 rm(list = ls())
@@ -40,6 +42,7 @@ library("httr")
 library(readxl) #Data Ingestion
 library(ggplot2) #Data Visualization
 ```
+
 ## Obtaining Data
 Reading and viewing the dataset
 ```r
@@ -93,6 +96,7 @@ drugs %>%
 ##                     Max.   :2017   Max.   :3.405e+11
 ##                                    NA's   :266
 ```
+
 ## Scrubbing data
 Removing rows with NA for the purposes of this visualization
 ```r
@@ -122,6 +126,7 @@ drugs %>%
 ## 10 Netherlands                59659401000
 ## # … with 210 more rows
 ```
+
 ## Exploring Data
 Lets plot the countries which were among the top 5 exporters each year and each of their performance over these 5 years.
 ```r

--- a/posts/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019.qmd
+++ b/posts/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019.qmd
@@ -27,6 +27,7 @@ keywords:
 ## Introduction
 From the article on [Seattle Times](https://www.seattletimes.com/seattle-news/transportation/what-we-can-learn-from-seattles-bike-counter-data/) -
 “While millions of public dollars are going for bike lanes in Seattle, the city’s data collection on actual bike-lane ridership is scattered and incomplete. Given they’re the best the public can get, here’s what those numbers can tell us about who’s riding where.”
+
 ## Analysis
 Following along the [screencast](https://www.youtube.com/watch?v=sBho2GJE5lc) from [David Robinson](https://twitter.com/drob)
 ```r
@@ -97,6 +98,7 @@ bike_traffic %>%
   facet_grid(crossing ~ direction)
 ```
 <img src="/post/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019_files/figure-html/unnamed-chunk-5-1.png" width="672" />
+
 ### When in the day do we see bikers?
 ```r
 bike_traffic %>%
@@ -221,6 +223,7 @@ bike_traffic %>%
        x = "")
 ```
 <img src="/post/2019-04-13-what-we-can-learn-from-seattle-s-bike-counter-data-tidytuesday-apr-02-2019_files/figure-html/unnamed-chunk-13-1.png" width="672" />
+
 ### What directions do people commute by bike?
 ```r
 bike_traffic %>%

--- a/posts/2019-04-16-economist-s-visualization-mistakes.qmd
+++ b/posts/2019-04-16-economist-s-visualization-mistakes.qmd
@@ -29,7 +29,9 @@ From the article on [Mistakes, we’ve drawn a few](https://medium.economist.com
 “At The Economist, we take data visualisation seriously. Every week we publish around 40 charts across print, the website and our apps. With every single one, we try our best to visualise the numbers accurately and in a way that best supports the story. But sometimes we get it wrong. We can do better in future if we learn from our mistakes — and other people may be able to learn from them, too.”
 Here I will try and draw the improved plots as suggested by the article on economist or make a version I think is best.
 All this done towards the weekly social data project [Tidy Tuesday](https://github.com/rfordatascience/tidytuesday/tree/master/data/2019/2019-04-16).
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -40,6 +42,7 @@ library(gridExtra)
 library(scales)
 theme_set(theme_light())
 ```
+
 ## Analyzing Britain’s Political Left
 ```r
 corbyn <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/corbyn.csv")
@@ -70,6 +73,7 @@ corbyn %>%
        caption = "Based on data from The Economist about political left in Britain")
 ```
 <img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-3-1.png" width="672" />
+
 ## Analyzing decline of dog weights
 ```r
 dogs <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/dogs.csv")
@@ -104,6 +108,7 @@ dogs %>%
        caption = "Based on data from The Economist")
 ```
 <img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-5-1.png" width="672" />
+
 ## Analyzing Brexit data
 ```r
 brexit <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/brexit.csv")
@@ -143,6 +148,7 @@ brexit %>%
        color = "Response")
 ```
 <img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-7-1.png" width="672" />
+
 ## Analyzing US trade deficit
 ```r
 trade <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/trade.csv")
@@ -193,6 +199,7 @@ trade %>%
 grid.arrange(p1, p2, nrow = 1)
 ```
 <img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-9-1.png" width="672" />
+
 ## Analyzing pension benefits
 ```r
 pensions <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/pensions.csv")
@@ -228,6 +235,7 @@ pensions %>%
        caption = "Based on data from The Economist")
 ```
 <img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-11-1.png" width="672" />
+
 ## Analyzing EU balance
 ```r
 eu_balance <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/eu_balance.csv")
@@ -269,6 +277,7 @@ eu_balance %>%
        caption = "Based on data from The Economist")
 ```
 <img src="/post/2019-04-16-economist-s-visualization-mistakes_files/figure-html/unnamed-chunk-13-1.png" width="672" />
+
 ## Analyzing papers published
 ```r
 women_research <- readr::read_csv("https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2019/2019-04-16/women_research.csv")

--- a/posts/2019-04-22-the-mueller-report.qmd
+++ b/posts/2019-04-22-the-mueller-report.qmd
@@ -30,7 +30,9 @@ output-file: the-mueller-report.html
 
 # Introduction
 Analyzing the Special Counsel’s “Report On The Investigation Into Russian Interference In The 2016 Presidential Election” from - [justice.gov](https://www.justice.gov/storage/report.pdf).
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -50,6 +52,7 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Downloading Report
 If we want to download and parse the report ourselves we can do so as follows -
 ```r
@@ -70,19 +73,23 @@ report %>%
 ## $ line <dbl> 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 1, 2, 3, 4, 5, 6…
 ## $ text <chr> "U.S. Department of Justice", "AttarAe:,c\\\\'erlc Predtiet // M…
 ```
+
 ## Cleaning
+
 ### Page range
 As we see from the pdf, first few pages contain Title and Index of the report, and the actual report text starts from page 9. Filtering out all the other pages for exploration
 ```r
 report %>%
   filter(page >= 9) -> content
 ```
+
 ### Text NA
 There are about 386 rows with NA as text, these maybe because of parsing failures over redactions, among other things. Dropping them for now.
 ```r
 content %>%
   filter(!is.na(text)) -> content
 ```
+
 ### Misspelled Words
 ```r
 content %>%
@@ -97,11 +104,13 @@ Dropping all rows (around 400 rows) where percentage of misspelled words is more
 content %>%
   filter(perc_misspelled <= 0.5) -> content
 ```
+
 ### Normalize
 ```r
 content %>%
   unnest_tokens(text, text, token = "lines") -> content
 ```
+
 ## Most popular words
 ```r
 tidy_content <- content %>%
@@ -130,6 +139,7 @@ tidy_content %>%
        caption = "Based on data from the Mueller Report")
 ```
 <img src="/post/2019-04-22-the-mueller-report_files/figure-html/unnamed-chunk-10-1.png" width="672" />
+
 ## Most dramatic pages
 Using python’s NLTK’s Vader Lexicon to generate sentiments for each line.
 ```python
@@ -200,6 +210,7 @@ content %>%
 ##  9 "guilty, pursuant to a single-count information , to identity fraud , …   183
 ## 10 "difficult to argue that hacked emails in electronic form, which are t…   184
 ```
+
 ## Most Common Correlated Words
 ```r
 word_cors <- tidy_content %>%
@@ -228,6 +239,7 @@ word_cors %>%
 ```
 <img src="/post/2019-04-22-the-mueller-report_files/figure-html/unnamed-chunk-16-1.png" width="672" />
 Words like “mcgahn” and “comey” show up as centers of correlation network.
+
 ## Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make this document more easily searchable and gain context using most related lines in the report for a given query.
 Using python’s scikit-learn for this.
@@ -247,6 +259,7 @@ def get_related_lines(query):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Search Query - Michael Cohen
 ```r
 content %>%
@@ -269,6 +282,7 @@ content %>%
 ```
 One of the interesting results from above (page 357) -
 “Toll records show that Cohen was connected to a White House phone number for approximately five minutes on January 19, 2018, and for approximately seven minutes on January 30, 2018, and that Cohen called Melania Trump’s cell phone several times between January 26, 2018, and January 30, 2018. Call Records of Michael Cohen.”
+
 ### Search Query - Vladimir Putin
 ```r
 content %>%
@@ -291,8 +305,10 @@ content %>%
 ```
 One of the interesting results from above (page 92) -
 “On March 24, 2016, Papadopoulos met with Mifsud in London. Mifsud was accompanied by a russian female named olga polonskaya. Mifsud introduced Polonskaya as a former student of his who had connections to Vladimir Putin”
+
 ## Late Night Hosts’ Jokes
 Lets see if we can catch (or fact check, if you will), any of the late night hosts’ jokes about the Mueller Report.
+
 ### Trevor Noah
 {{< video https://www.youtube.com/embed/pVbwZg8rM2c >}}
 ```r
@@ -317,6 +333,7 @@ content %>%
 ## 10 "difficult to argue that hacked emails in electronic form, which…   184    27
 ```
 The joke at around 34secs into the video can be clearly seen above as the 2nd highest polarized line in the report (page 290, line 20).
+
 ### Stephen Colbert
 {{< video https://www.youtube.com/embed/7MursWMNONo >}}
 ```r
@@ -340,6 +357,7 @@ content %>%
 ```
 The discussion about OLC from the video above at around 9min48secs can be seen in multiple instances as per our search engine, notably here (page 390) -
 “Impeachment is also a drastic and rarely invoked remedy, and Congress is not restricted to relying only on impeachment, rather than making criminal law applicable to a former President, as OLC has recognized.”
+
 ### Jimmy Fallon
 {{< video https://www.youtube.com/embed/TJZf0JIdqqU >}}
 ```r
@@ -366,6 +384,7 @@ The joke in the video around 3mins can be seen by the search query which leads t
 resign. McGahn recalled that, after speaking with his attorney and given the nature of the
 President’s request, he decided not to share details of the President’s request with other White
 House staff.”
+
 ### Jimmy Kimmel
 {{< video https://www.youtube.com/embed/NB7ZMczCXEM >}}
 ```r
@@ -389,8 +408,10 @@ content %>%
 ```
 The discussion at around 50secs into the video can be obtained from the above search query, from page 13 -
 “Although the investigation established that the Russian government perceived it would benefit from a Trump presidency and worked to secure that outcome, and that the Campaign expected it would benefit electorally from information stolen and released through Russian efforts, the investigation did not establish that members of the Trump Campaign conspired or coordinated with the Russian government in its election interference activities.”
+
 # Summary
 Looks like all the above tools can be pretty handy in doing a quick and thorough investigation of a large document in a very small amount of time (and its pretty fun too!)
+
 # References
 
 - [Kaggle data reference](https://www.kaggle.com/paultimothymooney/mueller-report)

--- a/posts/2019-05-07-india-general-elections-2019-analysis.qmd
+++ b/posts/2019-05-07-india-general-elections-2019-analysis.qmd
@@ -25,6 +25,7 @@ output-file: india-general-elections-2019-analysis.html
 
 # Project Summary
 With a whole lot of buzz in India (and world) about the 2019 General Elections in India, I thought it would be a good idea to do some election analysis of these pivotal elections in India’s history. I’ll start with analyzing the 2019 Election Manifestos of the 2 biggest political parties in India, the [Bhartiya Janta Party](https://www.bjp.org) and the [Indian National Congress](https://www.inc.in).
+
 # Project Goals
 
 - Data collection and cleaning for the election manifestos of the 2 parties.

--- a/posts/2019-05-08-india-elections-2019-bjp-vs-congress-manifestos-analysis.qmd
+++ b/posts/2019-05-08-india-elections-2019-bjp-vs-congress-manifestos-analysis.qmd
@@ -33,7 +33,9 @@ output-file: india-elections-2019-bjp-vs-congress-manifestos-analysis.html
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 1, I’ll collect and clean data and setup the ground work for the project.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -53,6 +55,7 @@ library(ggraph)
 theme_set(theme_light())
 use_python("~/anaconda3/bin/python")
 ```
+
 ## Downloading Manifestos
 BJP’s Manifesto available at their website - [bjp.org](https://www.bjp.org/manifestoPDF/BJP-Election-english-2019.pdf)
 ```r
@@ -104,7 +107,9 @@ congress %>%
 ## $ line <int> 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1…
 ## $ text <chr> "CONGRESS", "WILL", "DELIVER", "      MANIFESTO", "      LOK SAB…
 ```
+
 ## Cleaning
+
 ### Page range
 As we see from the 2 documents, first few pages contain Title and Index of the manifestos, and then moves on to the notes from the Party Leaders. The actual plans for development and work starts from page 11 in BJP’s manifesto and page 7 in Congress’. Filtering out all the other pages for exploration
 ```r
@@ -115,6 +120,7 @@ bjp %>%
 congress %>%
   filter(page >= 7) -> congress_content
 ```
+
 ### Text NA
 Dropping all the rows where we dont have any text.
 ```r
@@ -123,6 +129,7 @@ bjp_content %>%
 congress_content %>%
   filter(!is.na(text)) -> congress_content
 ```
+
 ### Normalize
 Normalizing text lines.
 ```r
@@ -132,6 +139,7 @@ congress_content %>%
   unnest_tokens(text, text, token = "lines") -> congress_content
 ```
 I’ll take a deep dive into individual topics of the manifestos in separate blog posts. For now, I will export our cleaned and normalized data for future analysis.
+
 ## Export Data
 ```r
 bjp_content %>%
@@ -140,6 +148,7 @@ congress_content %>%
   write_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
 Stay Tuned!
+
 # References
 
 - [Part 2 Economic Growth](/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth/)

--- a/posts/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth.qmd
+++ b/posts/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth.qmd
@@ -34,7 +34,9 @@ output-file: india-elections-2019-bjp-congress-manifestos-analysis-part2-economi
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 2, I’ll explore the Economic Growth discussions in both manifestos.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -54,11 +56,13 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Read cleaned data
 ```r
 bjp_content <- read_csv("../data/indian_election_2019/bjp_manifesto_clean.csv")
 congress_content <- read_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
+
 ## Economic Growth
 This topic is covered in congress’ manifesto from Pages 9 to 13 of the pdf and in that of bjp’s from pages 13 to 20.
 ```r
@@ -70,6 +74,7 @@ congress_content %>%
   filter(page >=9,
          page <= 13) -> congress_content
 ```
+
 ## Most Popular Words
 ```r
 plot_most_popular_words <- function(df,
@@ -122,6 +127,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))
 ```
 <img src="/post/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth_files/figure-html/unnamed-chunk-6-1.png" width="1344" />
+
 ## Common correlated words
 ```r
 plot_common_correlated_words <- function(df,
@@ -170,6 +176,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))
 ```
 <img src="/post/2019-05-09-india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth_files/figure-html/unnamed-chunk-8-1.png" width="1152" />
+
 ## Basic Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.
@@ -199,6 +206,7 @@ def get_related_lines(query, party="bjp"):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Common Popular Words with both BJP & Congress
 As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto for economy growth is “farmers”. Lets see, what each of them have planned for our farmers. First, BJP.
 ```r
@@ -250,6 +258,7 @@ One of the full excerpts from page 9 related to above results -
 <blockquote>
 Congress promises to establish a permanent National Commission on Agricultural Devel- opment and Planning consisting of farmers, agricultural scientists and agricultural economists to examine and advise the government on how to make agriculture viable, competitive and remuner- ative. The recommendations of the Commission shall be ordinarily binding on the government. The Commission will subsume the existing Commission for Agricultural Costs and Prices and recommend appropriate minimum support prices.
 </blockquote>
+
 ### Unique popular words with BJP & Congress
 One of the popular words that seems curious from BJP’s manifesto is “technology”. Let’s see what BJP has planned for the use of technology for economic growth.
 ```r
@@ -305,6 +314,7 @@ MSMEs account for 90 per cent of all employment outside agriculture. The definit
 </blockquote>
 With all the above analysis, we have developed some idea about the economic growth plans of the 2 parties. In the next post, I’ll do a similar analysis for employment and opportunites proposals of them.
 Stay Tuned!
+
 # References
 
 - [Part 1 - Data Collection and Cleaning](/2019/05/india-elections-2019-bjp-vs-congress-manifestos-analysis/)

--- a/posts/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
+++ b/posts/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
@@ -35,7 +35,9 @@ output-file: india-elections-2019-bjp-congress-manifestos-analysis-part-3-employ
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 3, I’ll explore the Employment and opportunities discussions in both manifestos.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -55,11 +57,13 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Read cleaned data
 ```r
 bjp_content <- read_csv("../data/indian_election_2019/bjp_manifesto_clean.csv")
 congress_content <- read_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
+
 ## Employment and Opportunities
 This topic is covered congress’ manifesto from Pages 6 to 8 of the pdf and in that of bjp’s from pages 20 to 22 and 27 to 28.
 ```r
@@ -69,6 +73,7 @@ bjp_content %>%
 congress_content %>%
   filter(between(page, 6, 8)) -> congress_content
 ```
+
 ## Most Popular Words
 ```r
 plot_most_popular_words <- function(df,
@@ -121,6 +126,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))
 ```
 <img src="/post/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-6-1.png" width="1344" />
+
 ## Common correlated words
 ```r
 plot_common_correlated_words <- function(df,
@@ -169,6 +175,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))
 ```
 <img src="/post/2019-05-10-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-8-1.png" width="1152" />
+
 ## Basic Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.
@@ -198,6 +205,7 @@ def get_related_lines(query, party="bjp"):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Common Popular Words with both BJP & Congress
 As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto for Employment and Opportunities is “electricity”. Lets see, what each of them have planned for that. First, BJP.
 ```r
@@ -250,6 +258,7 @@ One of the full excerpts from page 8 related to above results -
 <blockquote>
 Congress promises to enhance availability of, and access to, electricity in rural areas by encour- aging investment in off-grid renewable power generation with ownership and revenues vesting in local bodies. Every village and every home will be electrified in the true sense. In the long term, we aim to substitute LPG used in homes by electricity and solar energy.
 </blockquote>
+
 ### Unique popular words with BJP & Congress
 One of the popular words that seems curious from BJP’s manifesto is “youth”. Let’s see what BJP has planned for the youth employment opportunities.
 ```r
@@ -301,6 +310,7 @@ Tourism creates jobs. Congress promises an ade- quately capitalised Tourism Deve
 A surprisingly large amount of mention of the word “business”/“businesses” in this section of Congress’ manifesto.
 With all the above analysis, we have developed some idea about the Employment and Opportunities plans of the 2 parties. In the next post, I’ll do a similar analysis for Anti-Corruption and Good Governance proposals by them.
 Stay Tuned!
+
 # References
 
 - [Part 2 - Economic Growth](/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part2-economic-growth/)

--- a/posts/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
+++ b/posts/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities.qmd
@@ -35,7 +35,9 @@ output-file: india-elections-2019-bjp-congress-manifestos-analysis-part-4-anti-c
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 4, I’ll explore the Anti-corruption and Good Governance discussions in both manifestos.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -55,11 +57,13 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Read cleaned data
 ```r
 bjp_content <- read_csv("../data/indian_election_2019/bjp_manifesto_clean.csv")
 congress_content <- read_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
+
 ## Anti-Corruption and Good Governance
 This topic is covered congress’ manifesto from Pages 17 to 19 of the pdf and in that of bjp’s from pages 24 to 26.
 ```r
@@ -69,6 +73,7 @@ bjp_content %>%
 congress_content %>%
   filter(between(page, 17, 19)) -> congress_content
 ```
+
 ## Most Popular Words
 ```r
 plot_most_popular_words <- function(df,
@@ -121,6 +126,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))
 ```
 <img src="/post/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-6-1.png" width="1344" />
+
 ## Common correlated words
 ```r
 plot_common_correlated_words <- function(df,
@@ -169,6 +175,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))
 ```
 <img src="/post/2019-05-11-india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities_files/figure-html/unnamed-chunk-8-1.png" width="1152" />
+
 ## Basic Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.
@@ -198,6 +205,7 @@ def get_related_lines(query, party="bjp"):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Common Popular Words with both BJP & Congress
 As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto is “police”. Lets see, what each of them have planned for our police force. First, BJP.
 ```r
@@ -251,6 +259,7 @@ b. Decentralise the police force in the State and to involve the community in th
 police force.
 c. Cause investigations into cases of communal riots, lynchings and gang rapes by a special wing of the State police under the direct command of the State Headquarters of the police.
 </blockquote>
+
 ### Unique popular words with BJP & Congress
 One of the popular words that seems curious from BJP’s manifesto is “forest”.
 ```r
@@ -301,6 +310,7 @@ Congress was the proponent and author of the Constitution 73rd and 74th Amendmen
 </blockquote>
 With all the above analysis, we have developed some idea about the Anti-corruption and Good Governance ideologies of the 2 parties. In the next post, I’ll do a similar analysis for Inclusion and Diversity proposals by them.
 Stay Tuned!
+
 # References
 
 - [Part 3 - Employment and Opportunities](/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-3-employment-and-opportunities/)

--- a/posts/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity.qmd
+++ b/posts/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity.qmd
@@ -35,7 +35,9 @@ output-file: india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclus
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 5, I’ll explore the Inclusion and Diversity discussions in both manifestos.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -55,11 +57,13 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Read cleaned data
 ```r
 bjp_content <- read_csv("../data/indian_election_2019/bjp_manifesto_clean.csv")
 congress_content <- read_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
+
 ## Inclusion and Diversity
 This topic is covered congress’ manifesto from Pages 20 to 23 of the pdf and in that of bjp’s from pages 31 to 35.
 ```r
@@ -69,6 +73,7 @@ bjp_content %>%
 congress_content %>%
   filter(between(page, 20, 23)) -> congress_content
 ```
+
 ## Most Popular Words
 ```r
 plot_most_popular_words <- function(df,
@@ -121,6 +126,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))
 ```
 <img src="/post/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity_files/figure-html/unnamed-chunk-6-1.png" width="1344" />
+
 ## Common correlated words
 ```r
 plot_common_correlated_words <- function(df,
@@ -169,6 +175,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))
 ```
 <img src="/post/2019-05-12-india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity_files/figure-html/unnamed-chunk-8-1.png" width="1152" />
+
 ## Basic Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.
@@ -198,6 +205,7 @@ def get_related_lines(query, party="bjp"):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Common Popular Words with both BJP & Congress
 As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto is “women”. Lets see, what each of them have planned for women in our country. First, BJP.
 ```r
@@ -246,6 +254,7 @@ One of the excerpts from page 21 related to above results -
 <blockquote>
 We will stipulate that every Special Economic Zone shall have working women’s hostels and safe transport facilities to increase the participation of women in the labour force.
 </blockquote>
+
 ### Unique popular words with BJP & Congress
 One of the popular words that seems curious from BJP’s manifesto is “families”.
 ```r
@@ -296,6 +305,7 @@ Congress promises a Special Census and the enumeration of Denotified and Semi-No
 </blockquote>
 With all the above analysis, we have developed some idea about the Inclusion & Diversity plans of the 2 parties. In the next post, I’ll do a similar analysis for National Security proposals by them.
 Stay Tuned!
+
 # References
 
 - [Part 4 - Anti-Corruption and Good Governance](/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-4-anti-corruption-and-good-governance/)

--- a/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security.qmd
+++ b/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security.qmd
@@ -35,7 +35,9 @@ output-file: india-elections-2019-bjp-congress-manifestos-analysis-part-6-nation
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 6, I’ll explore the National Security discussions in both manifestos.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -55,11 +57,13 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Read cleaned data
 ```r
 bjp_content <- read_csv("../data/indian_election_2019/bjp_manifesto_clean.csv")
 congress_content <- read_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
+
 ## National Security
 This topic is covered congress’ manifesto from Pages 13 to 16 of the pdf and in that of bjp’s from pages 11 to 12 and 38 to 39.
 ```r
@@ -69,6 +73,7 @@ bjp_content %>%
 congress_content %>%
   filter(between(page, 13, 16)) -> congress_content
 ```
+
 ## Most Popular Words
 ```r
 plot_most_popular_words <- function(df,
@@ -121,6 +126,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))
 ```
 <img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security_files/figure-html/unnamed-chunk-6-1.png" width="1344" />
+
 ## Common correlated words
 ```r
 plot_common_correlated_words <- function(df,
@@ -169,6 +175,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))
 ```
 <img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security_files/figure-html/unnamed-chunk-8-1.png" width="1152" />
+
 ## Basic Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.
@@ -198,6 +205,7 @@ def get_related_lines(query, party="bjp"):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Common Popular Words with both BJP & Congress
 As we see from the plot above, one of the most popular words in both BJP and Congress’ is “terrorism”. Lets see, what each of them have planned to combat terrorism. First, BJP.
 ```r
@@ -247,6 +255,7 @@ One of the excerpts from page 14 related to above results -
 <blockquote>
 The concept of national security in the 21st century has expanded beyond defence of the territory to include data security, cyber security, financial security, communication security and security of trade routes. Congress promises to evolve suitable policies to address each of these subjects.
 </blockquote>
+
 ### Unique popular words with BJP & Congress
 One of the popular words that seems curious from BJP’s manifesto is “police”.
 ```r
@@ -297,6 +306,7 @@ We will accelerate the construction of border roads along all borders of India, 
 </blockquote>
 With all the above analysis, we have developed some idea about the National Security goals of the 2 parties. In the next post, I’ll do a similar analysis for Education Healthcare and other miscellaneous proposals by them.
 Stay Tuned!
+
 # References
 
 - [Part 5 - Inclusion and Diversity](/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-5-inclusion-diversity/)

--- a/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc.qmd
+++ b/posts/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc.qmd
@@ -35,7 +35,9 @@ output-file: india-elections-2019-bjp-congress-manifestos-analysis-part-7-educat
 # Introduction
 With India’s 2019 General Elections around the corner, I thought it’d be a good idea to analyse the election manifestos of its 2 biggest political parties, BJP and Congress. Let’s use text mining to understand what each party promises and prioritizes.
 In this part 7, I’ll explore the Education, Health Care and other miscellaneous discussions in both manifestos.
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -55,11 +57,13 @@ library(ggraph)
 theme_set(theme_light())
 use_condaenv("stanford-nlp")
 ```
+
 ## Read cleaned data
 ```r
 bjp_content <- read_csv("../data/indian_election_2019/bjp_manifesto_clean.csv")
 congress_content <- read_csv("../data/indian_election_2019/congress_manifesto_clean.csv")
 ```
+
 ## Education, Health Care and Miscellaneous
 This topic is covered congress’ manifesto from Pages 24 to 27 of the pdf and in that of bjp’s from pages 23 and 29 to 30 and 36 to 37.
 ```r
@@ -69,6 +73,7 @@ bjp_content %>%
 congress_content %>%
   filter(between(page, 24, 27)) -> congress_content
 ```
+
 ## Most Popular Words
 ```r
 plot_most_popular_words <- function(df,
@@ -121,6 +126,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(10,10))
 ```
 <img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc_files/figure-html/unnamed-chunk-6-1.png" width="1344" />
+
 ## Common correlated words
 ```r
 plot_common_correlated_words <- function(df,
@@ -169,6 +175,7 @@ congress_content %>%
 grid.arrange(p_bjp, p_congress, ncol = 2, widths = c(12,12))
 ```
 <img src="/post/2019-05-13-india-elections-2019-bjp-congress-manifestos-analysis-part-7-education-healthcare-misc_files/figure-html/unnamed-chunk-8-1.png" width="1152" />
+
 ## Basic Search Engine
 Lets build a cosine-similarity based simple search engine (instead of the basic keyword-based search that comes with the pdf document), in order to make these documents more easily searchable and gain context using most related lines in the manifestos for a given query.
 Using python’s scikit-learn for this.
@@ -198,6 +205,7 @@ def get_related_lines(query, party="bjp"):
 ```r
 get_related_lines <- py_to_r(py$get_related_lines)
 ```
+
 ### Common Popular Words with both BJP & Congress
 As we see from the plot above, one of the most popular words in both BJP and Congress’ manifesto is “children”. Lets see, what each of them have planned for the children of our country. First, BJP.
 ```r
@@ -247,6 +255,7 @@ One of the excerpts from page 25 related to above results -
 <blockquote>
 Congress promises that school education from Class I to Class XII in public schools shall be compulsory and free. Suitable amendments will be made in the Right to Education Act, 2009. We will end the practice of charging special fees for different purposes in public schools.
 </blockquote>
+
 ### Unique popular words with BJP & Congress
 One of the popular words that seems curious from BJP’s manifesto is “yoga”.
 ```r
@@ -298,6 +307,7 @@ Congress will take suitable measures to ensure that the Constitution of each spo
 With all the above analysis, we have developed some idea about the Education, Healthcare and other miscellaneous plans of the 2 parties.
 With this I conclude my analysis of the manifestos of BJP and Congress for 2019 general elections. I highly encourage all my readers to make their choice carefully in these pivotal elections and even though these analyses give you a high level idea about each party, maybe try and go through the entire manifestos to make a much informed decision about your choice and ensure accountability from our governments.
 Let’s hope for and build a better India. All the best!
+
 # References
 
 - [Part 6 - National Security](/2019/05/india-elections-2019-bjp-congress-manifestos-analysis-part-6-national-security/)

--- a/posts/2019-06-21-christmas-bird-counts-tidytuesday.qmd
+++ b/posts/2019-06-21-christmas-bird-counts-tidytuesday.qmd
@@ -28,7 +28,9 @@ output-file: christmas-bird-counts-tidytuesday.html
 # Introduction
 Visualizing bird watching data as collected in Hamilton area of Ontario during Christmas time since 1921.
 Working on the weekly social data project [Tidy Tuesday](https://github.com/rfordatascience/tidytuesday/tree/master/data/2019/2019-06-18).
+
 # Analysis
+
 ## Load libraries
 ```r
 rm(list = ls())
@@ -83,6 +85,7 @@ bird_counts %>%
 ##  Max.   :251.0   Max.   :439.024
 ##  NA's   :3781    NA's   :3781
 ```
+
 ## Which are the 5 most common birds over years?
 ```r
 bird_counts %>%

--- a/posts/2019-07-17-music-artist-recommendation-system-project.qmd
+++ b/posts/2019-07-17-music-artist-recommendation-system-project.qmd
@@ -25,6 +25,7 @@ output-file: music-artist-recommendation-system-project.html
 
 # Project Summary
 Recommendation systems are all around us, from Netflix’s amazing video recommender system to Amazon’s product recommendation system and many many more. I have always been curious about the science and effort that goes into building one and combining it with another one of my favorite topics, Music, would make it one of the more interesting projects that I try my hands on. Let’s see if we can build a music artist recommendation system that is similar to the ones built by Spotify or Amazon Music. I will use the [Last.fm Dataset](https://grouplens.org/datasets/hetrec-2011/) provided by GroupLens and works towards building a music artist recommendation system.
+
 # Project Goals
 
 - Exploratory data analysis of the Last.fm dataset.

--- a/posts/2019-07-18-music-recommendation-system.qmd
+++ b/posts/2019-07-18-music-recommendation-system.qmd
@@ -26,7 +26,9 @@ output-file: music-recommendation-system.html
 
 # Introduction
 Music Artist Recommendation System using the [Last.fm Dataset](https://grouplens.org/datasets/hetrec-2011/). Exploratory data analysis.
+
 # Analysis
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -41,6 +43,7 @@ library(htmlwidgets)
 
 theme_set(theme_light())
 ```
+
 ## Obtain Data
 ```r
 artists <- read_tsv("../data/hetrec2011-lastfm-2k/artists.dat")
@@ -98,7 +101,9 @@ ratings %>%
 ## $ artistID <dbl> 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, …
 ## $ weight   <dbl> 13883, 11690, 11351, 10300, 8983, 6152, 5955, 4616, 4337, 41…
 ```
+
 ## Scrub and Explore
+
 ### Ratings
 ```r
 ratings %>%
@@ -234,6 +239,7 @@ ratings %>%
 ## 10 498        399
 ## # … with 17,622 more rows
 ```
+
 ### Friends
 ```r
 friends %>%
@@ -278,6 +284,7 @@ friends %>%
 ## 10 390       88
 ## # … with 1,882 more rows
 ```
+
 ### Metadata
 ```r
 metadata %>%
@@ -426,7 +433,9 @@ snb <- htmlwidgets::prependContent(snb, htmltools::h2("Sunburst of most popular 
 snb <- htmlwidgets::prependContent(snb, htmltools::h5("Hover over to the see the artists and tags"))
 snb
 ```
+
 ## Sunburst of most popular artists in 5 most popular tags
+
 ##### Hover over to the see the artists and tags
 
 <input type="checkbox" class="sunburst-togglelegend" style="visibility:hidden;">Legend</input>
@@ -449,6 +458,7 @@ friends %>%
 metadata %>%
   write_csv("../data/hetrec2011-lastfm-2k/metadata_clean.csv")
 ```
+
 # References
 
 - [Data reference](https://grouplens.org/datasets/hetrec-2011/)

--- a/posts/2019-07-19-music-artist-recommendation-system-surprise.qmd
+++ b/posts/2019-07-19-music-artist-recommendation-system-surprise.qmd
@@ -21,7 +21,9 @@ output-file: music-artist-recommendation-system-surprise.html
 
 # Introduction
 Music Artist Recommendation System using the [Last.fm Dataset](https://grouplens.org/datasets/hetrec-2011/). Recommenders using Python’s Surprise Library.
+
 # Modelling
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -36,6 +38,7 @@ theme_set(theme_light())
 # use_condaenv("py-portfolioV2")
 use_condaenv("stanford-nlp")
 ```
+
 ## Obtain Data
 ```r
 ratings <- read_csv("../data/hetrec2011-lastfm-2k/ratings_clean.csv")
@@ -127,6 +130,7 @@ metadata %>%
 ## 10 55            173
 ## # … with 12,513 more rows
 ```
+
 # Python Surprise
 ```python
 import surprise

--- a/posts/2020-02-18-nlp-with-disaster-tweets.qmd
+++ b/posts/2020-02-18-nlp-with-disaster-tweets.qmd
@@ -25,6 +25,7 @@ output-file: nlp-with-disaster-tweets.html
 # Project Summary
 With this project, I’ll apply and practice various NLP techniques, along with trying my hands on the [tidymodels framework](https://github.com/tidymodels/tidymodels).
 I will use the [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle for its dataset and also evaluating model performance using submissions.
+
 # Project Goals
 
 - Apply and improve NLP skills in R & Python.

--- a/posts/2020-02-19-nlp-with-disaster-tweets-part-1.qmd
+++ b/posts/2020-02-19-nlp-with-disaster-tweets-part-1.qmd
@@ -27,7 +27,9 @@ output-file: nlp-with-disaster-tweets-part-1.html
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 1 for data preparation, I will do some basic exploration and vectorize the given tweet text into [glove](https://nlp.stanford.edu/projects/glove/) embedding vectors.
+
 # Analysis
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -41,6 +43,7 @@ library(janitor)
 
 theme_set(theme_light())
 ```
+
 ## Read Data
 ```r
 tweets <- read_csv("../data/nlp_with_disaster_tweets/train.csv")
@@ -181,6 +184,7 @@ skim(tweets)
 </tr>
 </tbody>
 </table>
+
 ## Getting glove embedding for tweet text and adding as features
 The simple workflow for vectorizing tweet text into glove embeddings is as follows -
 
@@ -234,6 +238,7 @@ str(padded_sequences)
 ##  int [1:7613, 1:33] 0 0 0 0 0 0 0 0 0 0 ...
 ```
 Like we see above, for all the 7,613 tweets in the training data we have created a tokenized sequence of 33 elements each.
+
 ### Download and parse glove embeddings into an embedding matrix for the tokenized words
 Downloaded the pre-trained glove embeddings trained on 2 billion tweets from Stanford’s NLP projects page on [Glove](https://nlp.stanford.edu/projects/glove/) and borrowing the code for parsing and generating glove embedding matrix from my [deepSentimentR](https://adityamangal410.github.io/deepSentimentR/reference/index.html) package.
 ```r
@@ -286,6 +291,7 @@ str(embedding_matrix)
 ##  num [1:22701, 1:25] 0 0.7864 0.4186 0.7086 -0.0102 ...
 ```
 Using only 25 dimensional embedding in order to keep the computations fast, we have created an embedding matrix which holds the 25 dimension values for the most popular 22700 words in our tweets text data.
+
 ### Generate embeddings vector for tweets text in training data
 Using the keras modelling framework to generate embeddings for the given training data. We basically create a simple sequential model with one embedding layer whose weights we will freeze based on our embedding matrix created above, and a flattening layer that will flatten the output into a 2D matrix of dimensions (7613, 33x25).
 ```r
@@ -308,6 +314,7 @@ str(tweets_embeddings)
 ##  num [1:7613, 1:825] 0 0 0 0 0 0 0 0 0 0 ...
 ```
 For each of the 7,613 padded tweet sequences of upto max length 33, we use the keras model to “predict” and populate the embedding for each of those 33 words in the sequence and susequently flatten those to create a single feature vector of 33x25=825 dimensions.
+
 ### Generate embeddings vector for tweets text in test data
 Using the similar approach as above (i.e. tokenize, pad and vectorize using glove embeddings) on the test data, to generate similar embedding vector for text in the tweets test data. Note that, we use the previously fit text tokenizer on the train data to tokenize the test data.
 ```r
@@ -325,6 +332,7 @@ str(tweets_embeddings_test)
 ##  num [1:3263, 1:825] 0 0 0 0 0 0 0 0 0 0 ...
 ```
 We similarly get 825 embedding dimensions for 3,263 tweets in the test data.
+
 ### Append to given tweets features and export
 ```r
 tweets %>%
@@ -340,6 +348,7 @@ saveRDS(tweets_proc, "../data/nlp_with_disaster_tweets/tweets_proc.rds")
 saveRDS(tweets_test_proc, "../data/nlp_with_disaster_tweets/tweets_test_proc.rds")
 ```
 Exporting the appended feature set will help us work on this dataset for modelling. I will cover the modelling using the tidymodels framework in my upcoming posts.
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)

--- a/posts/2020-02-20-nlp-with-disaster-tweets-part-2-nearest-neighbor-models.qmd
+++ b/posts/2020-02-20-nlp-with-disaster-tweets-part-2-nearest-neighbor-models.qmd
@@ -27,7 +27,9 @@ output-file: nlp-with-disaster-tweets-part-2-nearest-neighbor-models.html
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 2 for Nearest Neighbor Modelling, I will use the processed data generated in [Part 1](/2020/02/nlp-with-disaster-tweets-part-1/) to train nearest neighbor models in order to predict if a tweet is about a real disaster or not using the tidymodels framework.
+
 # Analysis
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -38,6 +40,7 @@ library(silgelib)
 
 theme_set(theme_plex())
 ```
+
 ## Loading processed data from previous part
 ```r
 tweets <- readRDS("../data/nlp_with_disaster_tweets/tweets_proc.rds")
@@ -57,6 +60,7 @@ tweets_final %>%
 ```
 ## [1] 3263  829
 ```
+
 ## Feature preprocessing and engineering
 ```r
 tweets %>%
@@ -74,6 +78,7 @@ tweets %>%
 ## 1 0       4342
 ## 2 1       3271
 ```
+
 ### Split data
 Splitting the data into 3 sets. A test set of 10% data, a cross validation set of 20% data and a training set of 70% data. Training and validation sets will be used for training, tuning and validating performance of models and comparing among them. Test set will only be used for final estimation of the model performance on unknown data.
 ```r
@@ -106,6 +111,7 @@ dim(tweets_test)
 ```
 ## [1] 763 830
 ```
+
 ### Preparation Recipe
 I will use the recipe package from tidymodels to generate a recipe for data preprocessing and feature engineering.
 ```r
@@ -142,7 +148,9 @@ tweets_prep <- tweets_recipe %>%
   prep(training = tweets_train,
        strings_as_factors = FALSE)
 ```
+
 ## Modelling
+
 ### Baseline model
 I will first create a baseline model to beat. In this case, we can predict randomly in the ratio of target counts and evaluate the model performance accordingly.
 ```r
@@ -224,8 +232,10 @@ tweets_prep %>%
   select(id, target) %>%
   write_csv("../data/nlp_with_disaster_tweets/submissions/baseline_cvf_57_testf_57.csv")
 ```
+
 ### K-Nearest Neighbor model
 Let’s build a basic KNN model with some default number of neighbors to see how the modelling is done in this framework and checkout how the modelling output looks like.
+
 #### Basic
 ```r
 knn_spec <- nearest_neighbor(neighbors = 3) %>%
@@ -255,6 +265,7 @@ wf_fit$fit$MISCLASS
 ```
 The above shows a simple K-nearest neighbors model using the “kknn” engine. Gives about 0.3521021 of minimal misclassification.
 Let’s try and tune the number of neighbors (k) and see if we can interpret the underlying problem space.
+
 #### Tuning number of neighbors
 Using 5-fold cross validation and values of K going from 1 to 100.
 ```r
@@ -355,9 +366,11 @@ knn_last_fit %>%
 ## 3 roc_auc  binary         0.687
 ```
 Our final fit knn model with K=25 gives an f1-score of 0.7560538, which is much higher than our baseline model on the same CV dataset.
+
 # Summary
 We can hence learn quite a few things about our underlying problem space by using this basic modelling algorithm K-nearest neighbors and use our learning in further model selection and tuning and also generate a fairly robust model that predicts quite effectively as compared to the baseline model.
 Also, this tidymodels framework provides a good modelling structure which can be easily reproduced and used to train a variety of models. In the next part of this series, I will work on another classic modelling algorithm, Lasso Regression, where we will also see if we can identify if there any of these features are much more important than the others and if our 2 custom features are useful.
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)

--- a/posts/2020-04-06-nlp-with-disaster-tweets-part-3-linear-models.qmd
+++ b/posts/2020-04-06-nlp-with-disaster-tweets-part-3-linear-models.qmd
@@ -27,7 +27,9 @@ output-file: nlp-with-disaster-tweets-part-3-linear-models.html
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 3 for Linear Modelling, I will use the processed data generated in [Part 1](/2020/02/nlp-with-disaster-tweets-part-1/) to train logistic regression based model with regularization in order to predict if a tweet is about a real disaster or not using the tidymodels framework. Following up from the previous [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/) about Nearest Neighbors model, I will do a comparative study among these 2 modelling algorithms.
+
 # Analysis
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -40,6 +42,7 @@ library(silgelib)
 
 theme_set(theme_plex())
 ```
+
 ## Loading processed data from previous part
 ```r
 tweets <- readRDS("../data/nlp_with_disaster_tweets/tweets_proc.rds")
@@ -59,6 +62,7 @@ tweets_final %>%
 ```
 ## [1] 3263  829
 ```
+
 ## Feature preprocessing and engineering
 I will use the same steps of feature preprocessing and engineering from [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/) here, in order to have an apples to apples comparison of the 2 models.
 ```r
@@ -91,9 +95,12 @@ tweets_prep <- tweets_recipe %>%
   prep(training = tweets_train,
        strings_as_factors = FALSE)
 ```
+
 ## Modelling
+
 ### Lasso Regression using glmnet
 Let’s build a basic logistic regression model with some default value of regularization penalty.
+
 #### Basic
 ```r
 lasso_spec <- logistic_reg(penalty = 0.1, mixture = 1) %>%
@@ -134,6 +141,7 @@ lasso_fit %>%
 ## # … with 11,674 more rows
 ```
 Above we see the familiar output of glmnet. Now, Let’s try and tune the regularization penalty and visualize the results.
+
 #### Tuning lasso penalty
 Using 10-fold cross validation and a few different values of regularization penalty.
 ```r
@@ -274,6 +282,7 @@ lasso_last_fit$.workflow[[1]] %>%
 ```
 <img src="/post/2020-04-06-nlp-with-disaster-tweets-part-3-linear-models_files/figure-html/unnamed-chunk-16-1.png" width="672" />
 All feature coefficients tend to move towards zero as we increase the lambda penalty parameter, some more quickly than others.
+
 ## Model Calibration
 Another method to measure model performance is to see how well calibrated a model is on the validation dataset. Let’s compare our 2 models, lasso regression here and the best k-nearest neighbor model from [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/), by plotting calibration plots for each of them.
 ```r
@@ -322,8 +331,10 @@ In general, closer the calibration curve to the diagonal, the better. When a mod
 The KNN model calibration plot shows that the curve is above the diagonal, i.e. the model is frequently under estimating the predicted probabilities.
 However, the lasso regression seems to be well calibrated out of the box. That’s a sign of good stable algorithm and training procedure.
 Note that all the predicted probabilities here are calculated on the cross validation set.
+
 # Summary
 In the next part of this series, I will start building models with a different class of function space, like piece-wise constant functions and linear combination of piece-wise constant functions classes i.e. simple decision trees and gradient boosted trees respectively. As we see in this blog post that the class of linear functions do give better performing models and we learnt our problem space to be leaning towards flexible models in [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/), I expect to see better results for different, more flexible modelling approaches.
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)

--- a/posts/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us.qmd
+++ b/posts/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us.qmd
@@ -27,7 +27,9 @@ output-file: nlp-with-disaster-tweets-part-4-tree-based-models.en-us.html
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 4 for Tree based Modelling, I will use the processed data generated in [Part 1](/2020/02/nlp-with-disaster-tweets-part-1/) to train decision trees and gradient boosted tree based models in order to predict if a tweet is about a real disaster or not using the tidymodels framework. Following up from the previous [Part 3](/2020/04/nlp-with-disaster-tweets-part-3-linear-models/) about Linear models, I will do a comparative study among all these modelling algorithms.
+
 # Analysis
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -41,6 +43,7 @@ library(rpart.plot)
 
 theme_set(theme_plex())
 ```
+
 ## Loading processed data from previous part
 ```r
 tweets <- readRDS("../data/nlp_with_disaster_tweets/tweets_proc.rds")
@@ -60,6 +63,7 @@ tweets_final %>%
 ```
 ## [1] 3263  829
 ```
+
 ## Feature preprocessing and engineering
 I will use the same steps of feature preprocessing and engineering from [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/) here, in order to have an apples to apples comparison of all the models.
 ```r
@@ -92,9 +96,12 @@ tweets_prep <- tweets_recipe %>%
   prep(training = tweets_train,
        strings_as_factors = FALSE)
 ```
+
 ## Modelling
+
 ### Decision Trees using rpart
 Let’s build a basic decision tree model with default values.
+
 #### Basic
 ```r
 dtree_spec <- decision_tree() %>%
@@ -119,8 +126,10 @@ pull_workflow_fit(dtree_fit)$fit %>%
 ```
 <img src="/post/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us_files/figure-html/unnamed-chunk-7-1.png" width="672" />
 Above we see the familiar plot of rpart, showing PC009 to be the most important variable.
+
 ### Gradient Boosted Trees using xgboost
 Let’s build a basic boosted tree model with default values.
+
 #### Basic
 ```r
 gbtree_spec <- boost_tree() %>%
@@ -140,6 +149,7 @@ saveRDS(gbtree_fit, "../data/nlp_with_disaster_tweets/trees/gbtree_basic_fit.rds
 ```r
 gbtree_fit <- readRDS("../data/nlp_with_disaster_tweets/trees/gbtree_basic_fit.rds")
 ```
+
 #### Tuning boosted tree parameters
 Using 5-fold cross validation and a few different values of various parameters.
 ```r
@@ -257,6 +267,7 @@ gbtree_last_fit$.workflow[[1]] %>%
 ```
 <img src="/post/2020-04-19-nlp-with-disaster-tweets-part-4-tree-based-models.en-us_files/figure-html/unnamed-chunk-18-1.png" width="672" />
 Since most of our features are the dimensionally reduced different dimensions coming out of the glove embeddings, we can not interpret them. However, one thing to note here, for gradient boosted trees, none of our custom features turn out to be of any significant importance.
+
 ## Model Calibration
 Another method to measure model performance is to see how well calibrated a model is on the validation dataset. Let’s compare our 3 models, gradient boosted trees here, lasso regression in [Part 3](/2020/04/nlp-with-disaster-tweets-part-3-linear-models/) and the best k-nearest neighbor model from [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/), by plotting calibration plots for each of them.
 ```r
@@ -326,8 +337,10 @@ In general, closer the calibration curve to the diagonal, the better. When a mod
 The KNN model calibration plot shows that the curve is above the diagonal, i.e. the model is frequently under estimating the predicted probabilities.
 However, both lasso regression and gradient boosted tree models seem to be well calibrated out of the box. That’s a sign of good stable algorithm and training procedure.
 Note that all the predicted probabilities here are calculated on the cross validation set.
+
 # Summary
 In this part I built tree based models in order to understand how the problem space can be modelled with these approaches. We do see a small improvement in f1-score as compared to all our previous approaches. Note that, due to limited compute resources on my mac, I have kept the size of tuning grid to be small. In the next part of this series, I will move focus towards neural networks based models and see how “deep” we can go. Other NLP strategies like Named-entity recognition and others are also on my bucket list for this series.
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)

--- a/posts/2020-05-14-from-tensorflow-to-pytorch.en-us.qmd
+++ b/posts/2020-05-14-from-tensorflow-to-pytorch.en-us.qmd
@@ -36,7 +36,9 @@ Any neural network model training workflow follows the following basic steps -
 - Repeat step 2 above for another epoch.
 
 I will use the same above blueprint and build model in both these frameworks. Note that I am using Tensorflow’s [quickstart tutorial](https://www.tensorflow.org/tutorials/quickstart/beginner) as the toy model and will build corresponding model in PyTorch.
+
 # Modelling
+
 ## Load Libraries
 ```r
 rm(list = ls())
@@ -57,7 +59,9 @@ import numpy as np
 
 torch.__version__
 ```
+
 ## Tensorflow
+
 ### Prep Data
 ```python
 mnist = tf.keras.datasets.mnist
@@ -67,6 +71,7 @@ x_train, x_test = x_train / 255.0, x_test / 255.0
 print('X_TRAIN: {0} Y_TRAIN: {1} \n X_TEST: {2} Y_TEST: {3}'.format(x_train.shape, y_train.shape, x_test.shape, y_test.shape))
 ```
 Using the classic MNIST dataset to predict the handwritten digit.
+
 ### Network Architecture
 ```python
 model = tf.keras.models.Sequential([
@@ -84,6 +89,7 @@ model.compile(optimizer='adam',
 ```
 In the above simple network, we first flatten the 2d image of the handwritten digits from 28x28 pixel values to single vector of 784 values. Next, we apply a fully connected dense layer with 128 hidden nodes and relu activation. Followed by a dropout layer with 20% dropout probability and then our final Dense layer that calculates the log-odds for each of the 10 digits.
 Next we define our loss function, the categorical cross entropy function (with parameters that uses logits to calculate the loss value) and the Adam Optimizer that will help train the network more efficiently as compared to using a simple gradient descent optimizer.
+
 ### Fit and evaluate
 ```python
 model.fit(x_train, y_train, epochs=5)
@@ -101,7 +107,9 @@ probability_model(x_test[:3]).numpy()
 ```
 In order to calculate predicted probability for each digit (instead of log-odds), we run our model output through a simple softmax function and display the predicted probabilities for the first 3 samples in the test data.
 Now moving on to PyTorch!
+
 ## PyTorch
+
 ### Prep data
 ```python
 x_train_torch = torch.from_numpy(x_train)
@@ -116,6 +124,7 @@ y_train_torch = y_train_torch.long()
 y_test_torch = y_test_torch.long()
 ```
 We are using the same MNIST dataset we used for building our Tensorflow example but converting it to PyTorch tensors and making sure they have the correct datatypes.
+
 ### Network Architecture
 ```python
 class Net(nn.Module):
@@ -139,6 +148,7 @@ optimizer = optim.Adam(torch_model.parameters(), lr = 0.001)
 ```
 With PyTorch, we get to build the network architecture in a more object oriented fashion where we define each layer in the class constructor and a forward function that defines how the input data will pass forward through the network. Note that, we do not need to have a separate “Flatten” layer in PyTorch like we did in Tensorflow, we can just restructure the tensor using the “view” function to achieve the same effect.
 We define the same loss function (CrossEntropyLoss), note however PyTorch’s CrossEntropyLoss function applies Softmax internally. We also initialize our Adam optimizer object.
+
 ### Fit and evaluate
 ```python
 torch_model.train()
@@ -165,6 +175,7 @@ preds = np.argmax(preds, axis=1)
 np.mean(y_test_torch.numpy() == preds)
 ```
 I also wanted to run this network through a simple gradient descent instead of a pre-built optimizer just out of curiosity to see how well it performs.
+
 ### Simple Gradient Descent
 ```python
 torch_model = Net()
@@ -193,8 +204,10 @@ preds = np.argmax(preds, axis=1)
 np.mean(y_test_torch.numpy() == preds)
 ```
 So intead of using the adam optimizer, we manually use the learning rate and the computed gradient for each parameter and update the value for each param during an epoch. As we see the model doesn’t perform quite as well, but nevertheless we now know how we can use PyTorch’s cool API to fully control every aspect of training the neural network.
+
 # Summary
 In summary, I think both Tensorflow and PyTorch provide solid frameworks for training neural networks. If you prefer more intuitive, easy-to-use API Tensorflow should be the way to go and if you like a neat object-oriented, more fine-grained control API then PyTorch serves that purpose well.
+
 # References
 
 - Tensorflow’s [quickstart tutorial](https://www.tensorflow.org/tutorials/quickstart/beginner)

--- a/posts/2020-08-25-nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us.qmd
+++ b/posts/2020-08-25-nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us.qmd
@@ -27,8 +27,10 @@ output-file: nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-u
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 5 for Deep Learning data preparation, I will use the raw data with the splits generated in [Part 2](/2020/02/nlp-with-disaster-tweets-part-2-nearest-neighbor-models/) to create a single class of Data Module that holds all the preprocessing, vectorization and PyTorch DataLoaders implementation as preparation for use in future deep learning models using PyTorch. Following up from the previous [Part 4](/2020/04/nlp-with-disaster-tweets-part-4-tree-based-models.en-us/) about tree-based models, I will move to creating Neural Networks to classify these tweets in upcoming posts.
+
 # Vocabulary, Vectorizer and More
 I will be using the [pytorch-lightning](https://github.com/PyTorchLightning/pytorch-lightning#pytorch-lightning-masterclass) framework to build a consistent DataModule class which will hold the logic of generating train, val and test datasets and creating corresponding data loaders that manage in-built batching and shuffling functionality. First things first, let’s start with the Vocabulary class.
+
 ## Vocabulary
 The vocabulary class will be responsible for converting the individual tokens (i.e. words) in our tweets to numerical indices. It is basically a simple dictionary with some sugar.
 ```python
@@ -83,6 +85,7 @@ class SequenceVocabulary(Vocabulary):
         else:
             return self._token_to_idx[token]
 ```
+
 ## Vectorizer
 Now that we have our vocabulary in place, we will need a vectorizer class that will, given a dataframe, create the exact vocabulary for the given dataset and also provide functionality to transform a single tweet text into a numerical vector representation.
 ```python
@@ -190,6 +193,7 @@ to -
 [2, 4, 5, 6, 7, 8, 3, 0, 0, 0, 0, 0, 0, ….. 0]
 </blockquote>
 with 0s appended in the end uptil the length of the longest tweet.
+
 ## Dataset
 Now we are ready to create the Dataset object for our data which is the abstraction provided by PyTorch for easy data transport and loading.
 ```python
@@ -225,6 +229,7 @@ class TweetsDataset(Dataset):
 - It runs the vectorization and returns all the relevant fields.
 
 We will create 3 instances of the TweetsDataset class, one for each train, val and test splits. These will be used in the Data Module accordingly to load data via Data Loaders.
+
 ## Data Module
 PyTorch Lightning provides a fantastic [LightningDataModule](https://pytorch-lightning.readthedocs.io/en/latest/datamodules.html?highlight=datamodule) class that helps create a shareable, reusable object that encapsulates all the steps needed to process data.
 ```python
@@ -292,6 +297,7 @@ The above code shows the most important components of the LightningDataModule cl
 
 # Summary
 In this part of the series, we have done our ground work for data preparation which we can use to jumpstart our Deep Learning modelling process. The full code for this class can be viewed on my github [here](https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/disaster_tweets_data_module.py). In the next part, I will start building a simple multi-layer perceptron using PyTorch Lightning and the DataModule class that we discussed in this part. See you there!
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)

--- a/posts/2020-09-02-nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us.qmd
+++ b/posts/2020-09-02-nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us.qmd
@@ -28,6 +28,7 @@ output-file: nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us.html
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 6 for building Multi Layer Perceptron, I will use the data module generated in [Part 5](/2020/08/nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us/) to create a Multi Layer Perceptron model to predict if the tweet is about a real disaster. Following up from the previous [Part 4](/2020/04/nlp-with-disaster-tweets-part-4-tree-based-models.en-us/) about tree-based models, I will generate the prediction output of this model on the validation set and compare results.
+
 # Classifier Class
 
 <img src="https://lh3.googleusercontent.com/UjkRMf-8bTQjE3bFfik8N4no1aH7m7J0PgZEmjuUh4uSLXpLsvSRy_lgOHsRkbPnLQ1CYLPjX6WwEZQpeAuikZi_hfSqKoYw6afUzPYuteoVf9wGmeVXJE7snQMi5oiG1sAuvNwYRJbyy7CuqdOhQSplrfMjJBwNT8xPanGEHwqdaHOiBuVyWr5yYNkJpwcbNbvlI542gq0ZBE5rYe1o4kiTmTwTpi8HaEJ8qjEbXamTDQQtEYiFcmsqBcCOl2uBLhbCtSAXJvz6WV2fN04x6QoGUaVz4ohQDYSYnkdSVWY4FcCAWMl7IrQJnhkZNTF33DWr9MXEtVEFVEVp6qOqMb0qwwPGwP08HMOrK2wPLVjhXRd_flitm3a3qhqMDp0kyjycW5ZAdELWoBycSpdWHIAmev2AP3iDOkmfYUsJTTjK2nHazbEw1pIXKgnkdV4-SS-0xpW04iTtXaTPLaG9IVYOH92cR1LitfmZTJVnF4MxzDveqGQQWcTmZSfuvuNzAImvagx6KTTaQ_peIzsRzeo_LcDZHC2xrDLXoinEknvrNt4VhahVMD5C7Mq4fpVePqROTvfiB1jNbIXmovZPetmjESLt0egU-vPYq4gZbJvTmRrSOV2v4SH1kCKZQOnIkD72JnA-BDcSNGyuB_kmFUqSSEx9gcSyZPTa1VYdBy9rSauEPnWl08BY5cnreQ=w600-h331-no" alt="" />
@@ -44,6 +45,7 @@ In a deep learning training pipeline we need to configure the following 5 essent
 - **Training Step / Val Step / Test Step** - We configure specific to each phase (train/val/test) how exactly we will compute and report the loss.
 
 That’s it! Rest everything related to epoch loop, checkpointing, logging, book-keeping are handled by PyTorch Lightning so we do not need to implement that specifically (as we would have if we were to use vanilla PyTorch. example [here](/2020/05/from-tensorflow-to-pytorch.en-us)). In the rest of the post I will mainly discuss the above 5 components specific to building a Multi Layer Perceptron for our Disaster Tweets usecase.
+
 ## Network Architecture and Loss Function
 A multi layer perceptron is a simple neural network where neurons in each layer are fully connected to all the neurons in the next layer. Weights are applied to each input feature by a linear transform along with a bias and non-linearity is introduced via the activation function. Let’s see how our network architecture and loss function look.
 ```python
@@ -106,6 +108,7 @@ class DisasterTweetsClassifierMLP(pl.LightningModule):
                                 weight_decay=self.hparams.weight_decay)
 ```
 We are using the **Adam** optimizer for optimizer our network parameters which is a good default optimizer as it combines advantages of 2 other well known optimizers AdaGrad and RMSProp. [Here](https://machinelearningmastery.com/adam-optimization-algorithm-for-deep-learning/) is a gentle introduction on Adam optimizer. We pass in all our network parameters, the provided learning rate and weight decay hyper parameters to <code>torch.optim.Adam</code>.
+
 ## Forward Method
 ```python
 class DisasterTweetsClassifierMLP(pl.LightningModule):
@@ -117,6 +120,7 @@ class DisasterTweetsClassifierMLP(pl.LightningModule):
 ```
 In the forward pass through the network, we first generate the embeddings for our batch and also flatten it. For example, if we had batch size as 8 and each of the 8 samples were of normalized length 70, then the <code>self.emb</code> embedding layer will transform it to a tensor <code>8 x 70 x 25</code> (if we were to use 25 dimensional glove embeddings). i.e. it’ll extract the 25-dimensional embedding for each of 70 words in our 8 samples. Then the <code>view(batch.size(0), -1)</code> will flatten it such that the tensor will transform from <code>8 x 70 x 25</code> to <code>8 x 1750</code> (i.e. it’ll append the embedding vectors of all 70 words in the sample for all 8 samples).
 This flattened vector then gets passed through our <code>fc</code> fully connected layer and generates the output which gets returned.
+
 ## Training Step / Val Step / Test Step
 ```python
 class DisasterTweetsClassifierMLP(pl.LightningModule):
@@ -198,6 +202,7 @@ We can use the above method to run the trained model on new incoming text and ge
 
 # Summary
 In this part of the series, we built a multi-layer perceptron neural network architecture to predict if a tweet is about a real disaster using the PyTorch Lightning framework. We built this on top of the Lightning Data Module that we discussed in the previous post of this series. We can see that we get a good solid baseline performance from this network and can hopefully with further hyperparameter tuning improve it. The full code for this post can be viewed on my github [here](https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/3.2-am-pl-mlp-glove-disaster-tweets.py). In the next part, I will build a Recurrent Neural Network for this task using our same underlying data module. Hope to see you there.
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)

--- a/posts/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.qmd
+++ b/posts/2020-09-26-nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.qmd
@@ -28,6 +28,7 @@ output-file: nlp-with-disaster-tweets-part-7-vanilla-rnn-and-gru.en-us.html
 # Introduction
 In this [NLP getting started challenge](https://www.kaggle.com/c/nlp-getting-started) on kaggle, we are given tweets which are classified as 1 if they are about real disasters and 0 if not. The goal is to predict given the text of the tweets and some other metadata about the tweet, if its about a real disaster or not.
 In this part 7 for building RNNs, I will use the data module generated in [Part 5](/2020/08/nlp-with-disaster-tweets-part-5-deep-learning-data-preparation.en-us/) to create a RNN models to predict if the tweet is about a real disaster. Following up from the previous [Part 6](/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/) about multi-layer perceptron model, I will generate the prediction output of this model on the validation set and compare results.
+
 # Classifier
 I will be using the [pytorch-lightning](https://github.com/PyTorchLightning/pytorch-lightning) framework to build a classifier class.
 Let’s follow the same overall flow of modelling that we had in [Part 6](/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/). The training pipeline will have the following components -
@@ -40,11 +41,13 @@ Let’s follow the same overall flow of modelling that we had in [Part 6](/2020/
 - **Training Step / Val Step / Test Step**
 
 Note that the Loss Function, the Optimizer and the training/val/test steps remains the same as our Multilayer Perceptron from [Part 6](/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/), so I will only discuss the remaining 2 components in this part.
+
 ## Network Architecture
 The essential idea of a Recurrent Neural Network is to process the words (tokens) in an input sentence sequentially, by applying the same weights W repeatedly to the output of previous word. The output at each processed word is called the hidden state. It looks like the following pictorial representation.
 
 <img src="https://lh3.googleusercontent.com/pw/ACtC-3eaiycpvplnp4dqTjPVk3La1j605Lx0oqD3kbX_zgljdIqRAVKi_lvs1XQq9ET_PHfHEVpwrNMcx0YbWYy3KTTKkZnnECkoYtSud6OqrOQVjk-hLOxHOH3liJvkyiLhxLfjn0jCU6sVHRCEBGViLON5ew=w1423-h670-no?authuser=1" alt="" style="max-width:100%" />
 <p class="caption">Recurrent Neural Network Pictorial representation from [https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf](https://web.stanford.edu/class/archive/cs/cs224n/cs224n.1194/slides/cs224n-2019-lecture06-rnnlm.pdf)
+
 ### Vanilla RNNs for Sentence Classification
 In our usecase, we will use the above vanilla RNN to create a “Sentence Encoding” i.e. a vector of values that represent the given sentence and then pass that vector through another linear layer to make our final binary prediction of whether the given tweets is about a real disaster or not.
 The network architecture looks as follows.
@@ -150,6 +153,7 @@ This final vector then gets passed through our <code>fc</code> fully connected l
 
 # The Training Routine
 The training routine for these networks remains almost exactly the same as the one in [Part 6](/2020/09/nlp-with-disaster-tweets-part-6-multi-layer-perceptron.en-us/). Instead of instantiating an object of class <code>DisasterTweetsClassifierMLP</code>, we create objects of class <code>DisasterTweetsClassifierRNN</code> or <code>DisasterTweetsClassifierGRU</code>.
+
 # Results
 <table style="width:100%;">
 <colgroup>
@@ -246,6 +250,7 @@ The above table shows the results for the model’s performance on our validatio
 
 # Summary
 In this part of the series, we built a few Recurrent Neural Networks to predict if a tweet is about a real disaster using the PyTorch Lightning framework. We built this on top of the Lightning Data Module that we discussed in the previous post of this series. We can see that we get a good performance from this network and can hopefully with further hyperparameter tuning improve it. The full code for this post can be viewed on my github [here](https://github.com/adityamangal410/nlp_with_pytorch/blob/master/scripts/3.3-am-pl-rnn-glove-disaster-tweets.py). In the next part, I will use the Transformer Architecture based pre-trained models like BERT to generate predictions for our usecase.
+
 # References
 
 - Project Summary Page - [NLP with disaster tweets: Summary](/2020/02/nlp-with-disaster-tweets/)


### PR DESCRIPTION
## Summary
- add missing blank lines before headings in blog posts

## Testing
- `python3 - <<'PY'
import re,glob
files=glob.glob('posts/*.qmd')
for f in files:
    lines=open(f).read().splitlines()
    inside=False
    for i,line in enumerate(lines):
        if line.startswith('```'):
            inside=not inside
        if not inside and re.match(r'#+ ', line) and i>0 and lines[i-1].strip()!='':
            raise SystemExit(f'Missing blank line before heading in {f}:{i+1}')
PY`

------
https://chatgpt.com/codex/tasks/task_e_685072d628c0832a849da0d5a5da5f01