### PR TITLE
Enhance category links and widen homepage layout

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Blog Posts"
 jupyter: python3
+page-layout: full
 execute:
   echo: false
 ---

--- a/index.qmd
+++ b/index.qmd
@@ -31,8 +31,9 @@ def parse_front_matter(path):
             val = val.strip()
             if val == '':
                 values: List[str] = []
-                while i < len(lines) and lines[i].startswith('  -'):
-                    values.append(lines[i].strip()[2:].strip())
+                while i < len(lines) and lines[i].lstrip().startswith('- '):
+                    item = lines[i].lstrip()[2:].strip()
+                    values.append(item)
                     i += 1
                 yaml[key] = values
             else:

--- a/static/style.css
+++ b/static/style.css
@@ -46,9 +46,10 @@
 
 .cat-link {
   display: inline-block;
-  padding: 0.2em 0.5em;
-  margin-left: 0.2em;
-  background-color: #eee;
+  padding: 0.3em 0.6em;
+  margin: 0.1em 0.2em;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 0.8em;
   text-decoration: none;
@@ -56,7 +57,7 @@
 }
 
 .cat-link:hover {
-  background-color: #ddd;
+  background-color: #e0e0e0;
 }
 
 .about-img {
@@ -83,4 +84,9 @@
 img {
   max-width: 100%;
   height: auto;
+}
+
+/* Widen content area */
+main.content {
+  max-width: 1200px;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -88,5 +88,5 @@ img {
 
 /* Widen content area */
 main.content {
-  max-width: 1200px;
+  max-width: 1000px;
 }

--- a/tools/generate_categories.py
+++ b/tools/generate_categories.py
@@ -35,8 +35,9 @@ def parse_front_matter(path):
             val = val.strip()
             if val == '':
                 values: List[str] = []
-                while i < len(lines) and lines[i].startswith('  -'):
-                    values.append(lines[i].strip()[2:].strip())
+                while i < len(lines) and lines[i].lstrip().startswith('- '):
+                    item = lines[i].lstrip()[2:].strip()
+                    values.append(item)
                     i += 1
                 yaml[key] = values
             else:
@@ -134,8 +135,9 @@ def parse_post_front_matter(path):
             val = val.strip()
             if val == '':
                 values = []
-                while i < len(lines) and lines[i].startswith('  -'):
-                    values.append(lines[i].strip()[2:].strip())
+                while i < len(lines) and lines[i].lstrip().startswith('- '):
+                    item = lines[i].lstrip()[2:].strip()
+                    values.append(item)
                     i += 1
                 yaml[key] = values
             else:


### PR DESCRIPTION
## Summary
- widen the homepage by setting `page-layout: full`
- style category links as small buttons
- increase content width for all pages

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685085d3a5d0832ab11fb7e6a21dd0bd