### PR TITLE
Add marimo demo post

### DIFF
--- a/posts/2025-06-19-marimo-interactive-demo.qmd
+++ b/posts/2025-06-19-marimo-interactive-demo.qmd
@@ -1,0 +1,38 @@
+---
+title: "Interactive marimo Demo"
+author: Aditya Mangal
+date: '2025-06-19'
+categories:
+- Tutorials
+keywords:
+- marimo
+- interactive
+- python
+summary: "Demo of an interactive marimo notebook embedded in a Quarto post."
+format:
+  html:
+    theme: distill
+freeze: true
+output-file: marimo-interactive-demo.html
+---
+
+marimo lets you create reactive notebooks that run entirely in the browser using WebAssembly. Below is a simple example built with [`marimo`](https://github.com/marimo-team/marimo) and [`plotly`](https://plotly.com/).
+
+```python
+{# Setup}
+!include-tools "tools/marimo_demo.py"
+```
+
+You can export this notebook to a single self-contained HTML file with:
+
+```bash
+marimo export tools/marimo_demo.py --output marimo-demo.html
+```
+
+Then embed `marimo-demo.html` in your Quarto post via an `<iframe>`:
+
+```{=html}
+<iframe src="marimo-demo.html" width="100%" height="400"></iframe>
+```
+
+Give it a try! Use the slider to update the plotted squares interactively—all executed right in your browser via Pyodide.

--- a/tools/marimo_demo.py
+++ b/tools/marimo_demo.py
@@ -1,0 +1,21 @@
+import marimo
+import plotly.express as px
+
+mo = marimo.App()
+
+@mo.cell
+def _():
+    slider = mo.ui.slider(1, 10, 5, label="Number of points")
+    return slider
+
+@mo.cell
+def _(slider):
+    import pandas as pd
+    df = pd.DataFrame({'x': range(slider.value), 'y': [i**2 for i in range(slider.value)]})
+    fig = px.line(df, x='x', y='y', markers=True)
+    fig.update_layout(width=500, height=300)
+    fig.show()
+    return df
+
+if __name__ == "__main__":
+    mo.main()


### PR DESCRIPTION
## Summary
- add `tools/marimo_demo.py` showing how to build an interactive Plotly slider in a marimo app
- document how to embed the exported HTML in `posts/2025-06-19-marimo-interactive-demo.qmd`

## Testing
- `quarto render posts/2025-06-19-marimo-interactive-demo.qmd`

------
https://chatgpt.com/codex/tasks/task_e_6853893d535c832ab801b1ecf0a7ae11